### PR TITLE
Remove () from usize().

### DIFF
--- a/src/tpi/mod.rs
+++ b/src/tpi/mod.rs
@@ -136,7 +136,7 @@ impl<'t> TypeInformation<'t> {
     ///
     /// Note that primitive types are not stored in the PDB file, so the number of distinct types
     /// reachable via this `TypeInformation` will be higher than `len()`.
-    pub fn len(&self) -> usize() {
+    pub fn len(&self) -> usize {
         (self.header.maximum_type_index - self.header.minimum_type_index) as usize
     }
 


### PR DESCRIPTION
Parentheses after primitive types will be prohibited in the future by rust-lang/rust#42238. This patch will remove the parentheses.