### PR TITLE
Add support for reading and iterating over modules from the DBI stream

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -138,6 +138,20 @@ impl<'b> ParseBuffer<'b> {
         self.1
     }
 
+    /// Align the current position to the next multiple of `alignment` bytes.
+    #[doc(hidden)]
+    #[inline]
+    pub fn align(&mut self, alignment: usize) -> Result<()> {
+        let diff = self.1 % alignment;
+        if diff > 0 {
+            if self.len() < diff {
+                return Err(Error::UnexpectedEof);
+            }
+            self.1 += alignment - diff;
+        }
+        Ok(())
+    }
+
     /// Parse a `u8` from the input.
     #[doc(hidden)]
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ mod pdbi;
 
 // exports
 pub use common::{Error,Result,TypeIndex,RawString,Variant};
-pub use dbi::{DebugInformation};
+pub use dbi::{DebugInformation, Module, ModuleIter};
 pub use pdbi::{PDBInformation};
 pub use pdb::PDB;
 pub use source::*;


### PR DESCRIPTION
I started looking at the code to see if I could replicate the `dump_syms` tool we use, but one of the first things it does is iterate over the modules in the DBI stream. So I implemented that. I don't know if this is the best way to expose this or not, but it works. I compared the output of `llvm-pdbdump raw -modules` (grepped for `Name:`) and a program that is basically the example code I added here and they match exactly.