### PR TITLE
Add support for reading the module information stream for modules, iterating over module private symbols.

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -232,30 +232,30 @@ pub struct DBISectionContribution {
 #[derive(Debug, Copy, Clone)]
 pub struct DBIModuleInfo {
     /// Currently open module.
-    opened: u32,
+    pub opened: u32,
     /// This module's first section contribution.
-    section: DBISectionContribution,
+    pub section: DBISectionContribution,
     /// Flags, expressed as bitfields in the C struct:
     /// written, EC enabled, unused, tsm
     /// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/dbi/dbi.h#L1201-L1204
-    flags: u16,
+    pub flags: u16,
     /// Stream number of module debug info (syms, lines, fpo).
-    stream: u16,
+    pub stream: u16,
     /// Size of local symbols debug info in `stream`.
-    symbols_size: u32,
+    pub symbols_size: u32,
     /// Size of line number debug info in `stream`.
-    lines_size: u32,
+    pub lines_size: u32,
     /// Size of C13 style line number info in `stream`.
-    c13_lines_size: u32,
+    pub c13_lines_size: u32,
     /// Number of files contributing to this module.
-    files: u16,
+    pub files: u16,
     _padding: u16,
     /// Used as a pointer into an array of filename indicies in the Microsoft code.
-    filename_offsets: u32,
+    pub filename_offsets: u32,
     /// Source file name index.
-    source: u32,
+    pub source: u32,
     /// Path to compiler PDB name index.
-    compiler: u32,
+    pub compiler: u32,
 }
 
 fn parse_module_info(buf: &mut ParseBuffer) -> Result<DBIModuleInfo> {
@@ -293,6 +293,11 @@ fn parse_section_contribution(buf: &mut ParseBuffer) -> Result<DBISectionContrib
 ///
 /// A `Module` is a single item that contributes to the binary, such as an
 /// object file or import library.
+///
+/// Much of the useful information for a `Module` is stored in a separate stream in the PDB.
+/// It can be retrieved by calling [`PDB::module_info`] with a specific module.
+///
+/// [`PDB::module_info`]: struct.PDB.html#method.module_info
 #[derive(Debug, Clone)]
 pub struct Module<'m> {
     info: DBIModuleInfo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate uuid;
 // modules
 mod common;
 mod dbi;
+mod module_info;
 mod msf;
 mod pdb;
 mod source;
@@ -65,6 +66,7 @@ mod pdbi;
 // exports
 pub use common::{Error,Result,TypeIndex,RawString,Variant};
 pub use dbi::{DebugInformation, Module, ModuleIter};
+pub use module_info::ModuleInfo;
 pub use pdbi::{PDBInformation};
 pub use pdb::PDB;
 pub use source::*;

--- a/src/module_info.rs
+++ b/src/module_info.rs
@@ -1,0 +1,54 @@
+use common::*;
+use dbi::Module;
+use msf::Stream;
+use std::mem;
+use symbol::SymbolIter;
+
+/// The signature at the start of a module information stream.
+const MODI_SIGNATURE: u32 = 4;
+
+#[allow(dead_code)]
+enum Lines {
+    C11(usize),
+    C13(usize),
+}
+
+/// This struct contains data about a single module from its module info stream.
+///
+/// The module info stream is where private symbols and line info is stored.
+pub struct ModuleInfo<'m> {
+    stream: Stream<'m>,
+    symbols_size: usize,
+    _lines: Lines,
+}
+
+impl<'m> ModuleInfo<'m> {
+    /// Get an iterator over the private symbols of this module.
+    pub fn symbols(&self) -> Result<SymbolIter> {
+        let mut buf = self.stream.parse_buffer();
+        buf.parse_u32()?;
+        let symbols = buf.take(self.symbols_size - mem::size_of::<u32>())?;
+        Ok(SymbolIter::new(symbols.into()))
+    }
+}
+
+pub fn new_module_info<'s, 'm>(stream: Stream<'s>, module: &Module<'m>) -> Result<ModuleInfo<'s>> {
+    let info = module.info();
+    {
+        let mut buf = stream.parse_buffer();
+        if buf.parse_u32()? != MODI_SIGNATURE {
+            return Err(Error::UnimplementedFeature("Unsupported module info format"));
+        }
+    }
+    let lines = if info.lines_size > 0 {
+        Lines::C11(info.lines_size as usize)
+    } else {
+        Lines::C13(info.c13_lines_size as usize)
+    };
+    let symbols_size = info.symbols_size as usize;
+    Ok(ModuleInfo {
+        stream,
+        symbols_size,
+        _lines: lines,
+    })
+}

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -68,9 +68,7 @@ pub fn new_symbol_table(s: Stream) -> SymbolTable {
 impl<'t> SymbolTable<'t> {
     /// Returns an iterator that can traverse the symbol table in sequential order.
     pub fn iter(&self) -> SymbolIter {
-        SymbolIter{
-            buf: self.stream.parse_buffer(),
-        }
+        SymbolIter::new(self.stream.parse_buffer())
     }
 }
 
@@ -314,6 +312,12 @@ pub struct SymbolIter<'t> {
     buf: ParseBuffer<'t>,
 }
 
+impl<'t> SymbolIter<'t> {
+    pub fn new(buf: ParseBuffer<'t>) -> SymbolIter {
+        SymbolIter { buf }
+    }
+}
+
 impl<'t> FallibleIterator for SymbolIter<'t> {
     type Item = Symbol<'t>;
     type Error = Error;
@@ -328,7 +332,7 @@ impl<'t> FallibleIterator for SymbolIter<'t> {
         let symbol_length = self.buf.parse_u16()? as usize;
 
         // validate
-        if symbol_length <= 2 {
+        if symbol_length < 2 {
             // this can't be correct
             return Err(Error::SymbolTooShort);
         }


### PR DESCRIPTION
This patch adds a `PDB::module_info` function to get the module info stream
for a specific module, a new `ModuleInfo` struct to hold that stream's data,
and a `ModuleInfo::symbols` function to get a `SymbolIter` to iterate over
the module's private symbols.

It was also necessary to change `SymbolIter::next` to accept symbols that are
exactly 2 bytes in length, since there are symbols like that in the in-tree
test PDB (S_END, among others).

The pdb_symbols example was also changed to iterate over and print module
private symbols, although that's less useful than one might think because
`Symbol::parse` doesn't support the full set of symbol records that show
up there.

The module information stream also contains line info, so adding support for
that on top of this change should be straightforward.

I tried to add useful doc comments and examples, hopefully I followed the project conventions well enough!