### PR TITLE
Add separate structs for enum variants

### DIFF
--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 
 type TypeSet = BTreeSet<pdb::TypeIndex>;
 
-pub fn type_name<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet) -> pdb::Result<String> {
+pub fn type_name<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<String> {
     let mut name = match type_finder.find(type_index)?.parse()? {
         pdb::TypeData::Primitive { primitive_type, indirection } => {
             let mut name = match primitive_type {
@@ -107,7 +107,7 @@ impl<'p> Class<'p> {
         Ok(())
     }
 
-    fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet) -> pdb::Result<()> {
+    fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
             pdb::TypeData::FieldList { fields, continuation, .. } => {
                 for ref field in fields {
@@ -128,7 +128,7 @@ impl<'p> Class<'p> {
         Ok(())
     }
 
-    fn add_field(&mut self, type_finder: &pdb::TypeFinder<'p>, field: &pdb::TypeData<'p>, mut needed_types: &mut TypeSet) -> pdb::Result<()> {
+    fn add_field(&mut self, type_finder: &pdb::TypeFinder<'p>, field: &pdb::TypeData<'p>, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match field {
             &pdb::TypeData::Member { field_type, offset, ref name, .. } => {
                 // TODO: attributes (static, virtual, etc.)
@@ -276,7 +276,7 @@ struct Method<'p> {
 impl<'p> Method<'p> {
     fn find(
         name: pdb::RawString<'p>, attributes: pdb::FieldAttributes,
-        type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet
+        type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet
     ) -> pdb::Result<Method<'p>>
     {
         match type_finder.find(type_index)?.parse()? {
@@ -297,7 +297,7 @@ impl<'p> Method<'p> {
     }
 }
 
-fn argument_list<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet) -> pdb::Result<Vec<String>> {
+fn argument_list<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<Vec<String>> {
     match type_finder.find(type_index)?.parse()? {
         pdb::TypeData::ArgumentList { arguments } => {
             let mut args: Vec<String> = Vec::new();
@@ -320,7 +320,7 @@ struct Enum<'p> {
 }
 
 impl<'p> Enum<'p> {
-    fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet) -> pdb::Result<()> {
+    fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
             pdb::TypeData::FieldList { fields, continuation, .. } => {
                 for ref field in fields {
@@ -445,7 +445,7 @@ impl<'p> Data<'p> {
         }
     }
 
-    fn add(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, mut needed_types: &mut TypeSet) -> pdb::Result<()> {
+    fn add(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
             pdb::TypeData::Class {
                 kind, properties, fields, name, derived_from, ..

--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -11,30 +11,30 @@ type TypeSet = BTreeSet<pdb::TypeIndex>;
 
 pub fn type_name<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<String> {
     let mut name = match type_finder.find(type_index)?.parse()? {
-        pdb::TypeData::Primitive { primitive_type, indirection } => {
-            let mut name = match primitive_type {
-                pdb::PrimitiveType::Void => "void".to_string(),
-                pdb::PrimitiveType::Char => "char".to_string(),
-                pdb::PrimitiveType::UChar => "unsigned char".to_string(),
+        pdb::TypeData::Primitive(data) => {
+            let mut name = match data.kind {
+                pdb::PrimitiveKind::Void => "void".to_string(),
+                pdb::PrimitiveKind::Char => "char".to_string(),
+                pdb::PrimitiveKind::UChar => "unsigned char".to_string(),
 
-                pdb::PrimitiveType::I8 => "int8_t".to_string(),
-                pdb::PrimitiveType::U8 => "uint8_t".to_string(),
-                pdb::PrimitiveType::I16 => "int16_t".to_string(),
-                pdb::PrimitiveType::U16 => "uint16_t".to_string(),
-                pdb::PrimitiveType::I32 => "int32_t".to_string(),
-                pdb::PrimitiveType::U32 => "uint32_t".to_string(),
-                pdb::PrimitiveType::I64 => "int64_t".to_string(),
-                pdb::PrimitiveType::U64 => "uint64_t".to_string(),
+                pdb::PrimitiveKind::I8 => "int8_t".to_string(),
+                pdb::PrimitiveKind::U8 => "uint8_t".to_string(),
+                pdb::PrimitiveKind::I16 => "int16_t".to_string(),
+                pdb::PrimitiveKind::U16 => "uint16_t".to_string(),
+                pdb::PrimitiveKind::I32 => "int32_t".to_string(),
+                pdb::PrimitiveKind::U32 => "uint32_t".to_string(),
+                pdb::PrimitiveKind::I64 => "int64_t".to_string(),
+                pdb::PrimitiveKind::U64 => "uint64_t".to_string(),
 
-                pdb::PrimitiveType::F32 => "float".to_string(),
-                pdb::PrimitiveType::F64 => "double".to_string(),
+                pdb::PrimitiveKind::F32 => "float".to_string(),
+                pdb::PrimitiveKind::F64 => "double".to_string(),
 
-                pdb::PrimitiveType::Bool8 => "bool".to_string(),
+                pdb::PrimitiveKind::Bool8 => "bool".to_string(),
 
-                _ => format!("unhandled_primitive_type /* {:?} */", primitive_type),
+                _ => format!("unhandled_primitive.kind /* {:?} */", data.kind),
             };
 
-            match indirection {
+            match data.indirection {
                 pdb::Indirection::None => {},
                 _ => { name.push(' '); name.push('*'); },
             }
@@ -42,39 +42,39 @@ pub fn type_name<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeInd
             name
         },
 
-        pdb::TypeData::Class { name, .. } => {
+        pdb::TypeData::Class(data) => {
             needed_types.insert(type_index);
-            name.to_string().into_owned()
+            data.name.to_string().into_owned()
         },
 
-        pdb::TypeData::Enumeration { name, .. } => {
+        pdb::TypeData::Enumeration(data) => {
             needed_types.insert(type_index);
-            name.to_string().into_owned()
+            data.name.to_string().into_owned()
         },
 
-        pdb::TypeData::Union { name, .. } => {
+        pdb::TypeData::Union(data) => {
             needed_types.insert(type_index);
-            name.to_string().into_owned()
+            data.name.to_string().into_owned()
         },
 
-        pdb::TypeData::Pointer { underlying_type, .. } => {
-            format!("{}*", type_name(type_finder, underlying_type, needed_types)?)
+        pdb::TypeData::Pointer(data) => {
+            format!("{}*", type_name(type_finder, data.underlying_type, needed_types)?)
         },
 
-        pdb::TypeData::Modifier { constant, volatile, underlying_type, .. } => {
-            if constant {
-                format!("const {}", type_name(type_finder, underlying_type, needed_types)?)
-            } else if volatile {
-                format!("volatile {}", type_name(type_finder, underlying_type, needed_types)?)
+        pdb::TypeData::Modifier(data) => {
+            if data.constant {
+                format!("const {}", type_name(type_finder, data.underlying_type, needed_types)?)
+            } else if data.volatile {
+                format!("volatile {}", type_name(type_finder, data.underlying_type, needed_types)?)
             } else {
                 // ?
-                type_name(type_finder, underlying_type, needed_types)?
+                type_name(type_finder, data.underlying_type, needed_types)?
             }
         },
 
-        pdb::TypeData::Array { element_type, dimensions, .. } => {
-            let mut name = type_name(type_finder, element_type, needed_types)?;
-            for size in dimensions {
+        pdb::TypeData::Array(data) => {
+            let mut name = type_name(type_finder, data.element_type, needed_types)?;
+            for size in data.dimensions {
                 name = format!("{}[{}]", name, size);
             }
             name
@@ -109,12 +109,12 @@ impl<'p> Class<'p> {
 
     fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
-            pdb::TypeData::FieldList { fields, continuation, .. } => {
-                for ref field in fields {
+            pdb::TypeData::FieldList(data) => {
+                for ref field in data.fields {
                     self.add_field(type_finder, field, needed_types)?;
                 }
 
-                if let Some(continuation) = continuation {
+                if let Some(continuation) = data.continuation {
                     // recurse
                     self.add_fields(type_finder, continuation, needed_types)?;
                 }
@@ -130,33 +130,33 @@ impl<'p> Class<'p> {
 
     fn add_field(&mut self, type_finder: &pdb::TypeFinder<'p>, field: &pdb::TypeData<'p>, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match field {
-            &pdb::TypeData::Member { field_type, offset, ref name, .. } => {
+            &pdb::TypeData::Member(ref data) => {
                 // TODO: attributes (static, virtual, etc.)
                 self.fields.push(Field{
-                    type_name: type_name(type_finder, field_type, needed_types)?,
-                    name: name.clone(),
-                    offset: offset,
+                    type_name: type_name(type_finder, data.field_type, needed_types)?,
+                    name: data.name.clone(),
+                    offset: data.offset,
                 });
             },
 
-            &pdb::TypeData::Method { attributes, method_type, ref name, .. } => {
-                let method = Method::find(name.clone(), attributes, type_finder, method_type, needed_types)?;
-                if attributes.is_static() {
+            &pdb::TypeData::Method(ref data) => {
+                let method = Method::find(data.name.clone(), data.attributes, type_finder, data.method_type, needed_types)?;
+                if data.attributes.is_static() {
                     self.static_methods.push(method);
                 } else {
                     self.instance_methods.push(method);
                 }
             },
 
-            &pdb::TypeData::OverloadedMethod { method_list, ref name, .. } => {
+            &pdb::TypeData::OverloadedMethod(ref data) => {
                 // this just means we have more than one method with the same name
                 // find the method list
-                match type_finder.find(method_list)?.parse()? {
-                    pdb::TypeData::MethodList { method_list } => {
-                        let mut iter = method_list.into_iter();
+                match type_finder.find(data.method_list)?.parse()? {
+                    pdb::TypeData::MethodList(method_list) => {
+                        let mut iter = method_list.methods.into_iter();
                         while let Some(pdb::MethodListEntry { attributes, method_type, .. }) = iter.next() {
                             // hooray
-                            let method = Method::find(name.clone(), attributes, type_finder, method_type, needed_types)?;
+                            let method = Method::find(data.name.clone(), attributes, type_finder, method_type, needed_types)?;
                             if attributes.is_static() {
                                 self.static_methods.push(method);
                             } else {
@@ -165,23 +165,23 @@ impl<'p> Class<'p> {
                         }
                     }
                     other => {
-                        println!("processing OverloadedMethod, expected MethodList, got {} -> {:?}", method_list, other);
+                        println!("processing OverloadedMethod, expected MethodList, got {} -> {:?}", data.method_list, other);
                         panic!("unexpected type in Class::add_field()");
                     }
                 }
             },
 
-            &pdb::TypeData::BaseClass { base_class, offset, .. } => {
+            &pdb::TypeData::BaseClass(ref data) => {
                 self.base_classes.push(BaseClass{
-                    type_name: type_name(type_finder, base_class, needed_types)?,
-                    offset: offset,
+                    type_name: type_name(type_finder, data.base_class, needed_types)?,
+                    offset: data.offset,
                 })
             },
 
-            &pdb::TypeData::VirtualBaseClass { base_class, base_pointer_offset, .. } => {
+            &pdb::TypeData::VirtualBaseClass(ref data) => {
                 self.base_classes.push(BaseClass{
-                    type_name: type_name(type_finder, base_class, needed_types)?,
-                    offset: base_pointer_offset,
+                    type_name: type_name(type_finder, data.base_class, needed_types)?,
+                    offset: data.base_pointer_offset,
                 })
             },
 
@@ -280,11 +280,11 @@ impl<'p> Method<'p> {
     ) -> pdb::Result<Method<'p>>
     {
         match type_finder.find(type_index)?.parse()? {
-            pdb::TypeData::MemberFunction { return_type, argument_list: arg_list_type, .. } => {
+            pdb::TypeData::MemberFunction(data) => {
                 Ok(Method{
                     name: name,
-                    return_type_name: type_name(type_finder, return_type, needed_types)?,
-                    arguments: argument_list(type_finder, arg_list_type, needed_types)?,
+                    return_type_name: type_name(type_finder, data.return_type, needed_types)?,
+                    arguments: argument_list(type_finder, data.argument_list, needed_types)?,
                     is_virtual: attributes.is_virtual(),
                 })
             },
@@ -299,9 +299,9 @@ impl<'p> Method<'p> {
 
 fn argument_list<'p>(type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<Vec<String>> {
     match type_finder.find(type_index)?.parse()? {
-        pdb::TypeData::ArgumentList { arguments } => {
+        pdb::TypeData::ArgumentList(data) => {
             let mut args: Vec<String> = Vec::new();
-            for arg_type in arguments {
+            for arg_type in data.arguments {
                 args.push(type_name(type_finder, arg_type, needed_types)?);
             }
             Ok(args)
@@ -322,12 +322,12 @@ struct Enum<'p> {
 impl<'p> Enum<'p> {
     fn add_fields(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
-            pdb::TypeData::FieldList { fields, continuation, .. } => {
-                for ref field in fields {
+            pdb::TypeData::FieldList(data) => {
+                for ref field in data.fields {
                     self.add_field(type_finder, field, needed_types)?;
                 }
 
-                if let Some(continuation) = continuation {
+                if let Some(continuation) = data.continuation {
                     // recurse
                     self.add_fields(type_finder, continuation, needed_types)?;
                 }
@@ -343,10 +343,10 @@ impl<'p> Enum<'p> {
 
     fn add_field(&mut self, _: &pdb::TypeFinder<'p>, field: &pdb::TypeData<'p>, _: &mut TypeSet) -> pdb::Result<()> {
         match field {
-            &pdb::TypeData::Enumerate { ref name, value, .. } => {
+            &pdb::TypeData::Enumerate(ref data) => {
                 self.values.push(EnumValue{
-                    name: name.clone(),
-                    value: value,
+                    name: data.name.clone(),
+                    value: data.value,
                 });
             },
 
@@ -447,48 +447,44 @@ impl<'p> Data<'p> {
 
     fn add(&mut self, type_finder: &pdb::TypeFinder<'p>, type_index: pdb::TypeIndex, needed_types: &mut TypeSet) -> pdb::Result<()> {
         match type_finder.find(type_index)?.parse()? {
-            pdb::TypeData::Class {
-                kind, properties, fields, name, derived_from, ..
-            } => {
-                if properties.forward_reference() {
+            pdb::TypeData::Class(data) => {
+                if data.properties.forward_reference() {
                     self.forward_references.push(ForwardReference{
-                        kind: kind,
-                        name: name,
+                        kind: data.kind,
+                        name: data.name,
                     });
 
                     return Ok(());
                 }
 
                 let mut class = Class{
-                    kind: kind,
-                    name: name,
+                    kind: data.kind,
+                    name: data.name,
                     fields: Vec::new(),
                     base_classes: Vec::new(),
                     instance_methods: Vec::new(),
                     static_methods: Vec::new(),
                 };
 
-                if let Some(derived_from) = derived_from {
+                if let Some(derived_from) = data.derived_from {
                     class.add_derived_from(type_finder, derived_from, needed_types)?;
                 }
 
-                if let Some(fields) = fields {
+                if let Some(fields) = data.fields {
                     class.add_fields(type_finder, fields, needed_types)?;
                 }
 
                 self.classes.insert(0, class);
             }
 
-            pdb::TypeData::Enumeration {
-                underlying_type, fields, name, ..
-            } => {
+            pdb::TypeData::Enumeration(data) => {
                 let mut e = Enum{
-                    name: name,
-                    underlying_type_name: type_name(type_finder, underlying_type, needed_types)?,
+                    name: data.name,
+                    underlying_type_name: type_name(type_finder, data.underlying_type, needed_types)?,
                     values: Vec::new(),
                 };
 
-                e.add_fields(type_finder, fields, needed_types)?;
+                e.add_fields(type_finder, data.fields, needed_types)?;
 
                 self.enums.insert(0, e);
             }
@@ -518,8 +514,8 @@ fn write_class(filename: &str, class_name: &str) -> pdb::Result<()> {
         // keep building the index
         type_finder.update(&type_iter);
 
-        if let Ok(pdb::TypeData::Class { name, properties, .. }) = typ.parse() {
-            if name.as_bytes() == class_name.as_bytes() && !properties.forward_reference() {
+        if let Ok(pdb::TypeData::Class(class)) = typ.parse() {
+            if class.name.as_bytes() == class_name.as_bytes() && !class.properties.forward_reference() {
                 data.add(&type_finder, typ.type_index(), &mut needed_types)?;
                 break;
             }

--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -17,11 +17,11 @@ fn print_row<'p>(segment: u16, offset: u32, kind: &'static str, name: pdb::RawSt
 
 fn print_symbol(symbol: &pdb::Symbol) -> pdb::Result<()> {
     match symbol.parse()? {
-        pdb::SymbolData::PublicSymbol{ function: true, segment, offset, .. } => {
-            print_row(segment, offset, "function", symbol.name()?);
+        pdb::SymbolData::PublicSymbol(data) => {
+            print_row(data.segment, data.offset, "function", symbol.name()?);
         }
-        pdb::SymbolData::DataSymbol{ segment, offset, .. } => {
-            print_row(segment, offset, "data", symbol.name()?);
+        pdb::SymbolData::DataSymbol(data) => {
+            print_row(data.segment, data.offset, "data", symbol.name()?);
         }
         _ => {
             // ignore everything else

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,7 @@ pub use pdbi::{PDBInformation};
 pub use pdb::PDB;
 pub use source::*;
 pub use symbol::*;
-pub use tpi::{Type,TypeFinder,TypeInformation,TypeIter,TypeData};
-pub use tpi::{ClassKind,FieldAttributes,FunctionAttributes,MethodListEntry,TypeProperties};
-pub use tpi::{Indirection,PrimitiveType};
+pub use tpi::*;
 
 // re-export FallibleIterator for convenience
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,9 @@
 //! let mut symbols = symbol_table.iter();
 //! while let Some(symbol) = symbols.next()? {
 //!     match symbol.parse() {
-//!     	Ok(pdb::SymbolData::PublicSymbol{
-//!     		function: true,
-//!     		segment,
-//!     		offset,
-//!     		..
-//!     	}) => {
+//!     	Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
 //!     		// we found the location of a function!
-//!     		println!("{:x}:{:08x} is {}", segment, offset, symbol.name()?);
+//!     		println!("{:x}:{:08x} is {}", data.segment, data.offset, symbol.name()?);
 //!             # count += 1;
 //!     	}
 //!     	_ => {}
@@ -70,7 +65,7 @@ pub use module_info::ModuleInfo;
 pub use pdbi::{PDBInformation};
 pub use pdb::PDB;
 pub use source::*;
-pub use symbol::{SymbolTable,Symbol,SymbolData,SymbolIter};
+pub use symbol::*;
 pub use tpi::{Type,TypeFinder,TypeInformation,TypeIter,TypeData};
 pub use tpi::{ClassKind,FieldAttributes,FunctionAttributes,MethodListEntry,TypeProperties};
 pub use tpi::{Indirection,PrimitiveType};

--- a/src/msf/page_list.rs
+++ b/src/msf/page_list.rs
@@ -42,7 +42,7 @@ impl PageList {
         if is_continuous {
             // extend by one page
             debug_assert!(self.source_slices.len() > 0);
-            let mut last_slice = self.source_slices.last_mut().unwrap();
+            let last_slice = self.source_slices.last_mut().unwrap();
             last_slice.size += self.page_size;
         } else {
             self.source_slices.push(SourceSlice{

--- a/src/source.rs
+++ b/src/source.rs
@@ -91,7 +91,7 @@ impl<'s, T> Source<'s> for T where T: io::Read + io::Seek + fmt::Debug + 's {
         v.bytes.resize(len, 0);
 
         {
-            let mut bytes = v.bytes.as_mut_slice();
+            let bytes = v.bytes.as_mut_slice();
             let mut output_offset: usize = 0;
             for slice in slices {
                 self.seek(io::SeekFrom::Start(slice.offset))?;

--- a/src/tpi/primitive.rs
+++ b/src/tpi/primitive.rs
@@ -22,8 +22,17 @@ use super::data::TypeData;
 // encoded into the bits of the TypeIndex rather than exploding the matrix like the reference
 // implementations.
 
+/// Represents a primitive type like `void` or `char *`.
 #[derive(Debug,Copy,Clone,PartialEq,Eq)]
-pub enum PrimitiveType {
+pub struct PrimitiveType {
+    pub kind: PrimitiveKind,
+
+    /// What kind of indirection was applied to the underlying type
+    pub indirection: Indirection,
+}
+
+#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+pub enum PrimitiveKind {
     Void,
 
     Char,
@@ -163,63 +172,63 @@ pub fn type_data_for_primitive(index: TypeIndex) -> Result<TypeData<'static>> {
 
     // primitive types are stored in the lowest octet
     // this groups "short" and "16-bit integer" together, but... right? *scratches head*
-    let primitive_type = match index & 0xff {
-        0x03 => PrimitiveType::Void,
-        0x08 => PrimitiveType::HRESULT,
+    let kind = match index & 0xff {
+        0x03 => PrimitiveKind::Void,
+        0x08 => PrimitiveKind::HRESULT,
 
-        0x10 => PrimitiveType::Char,
-        0x20 => PrimitiveType::UChar,
-        0x68 => PrimitiveType::I8,
-        0x69 => PrimitiveType::U8,
+        0x10 => PrimitiveKind::Char,
+        0x20 => PrimitiveKind::UChar,
+        0x68 => PrimitiveKind::I8,
+        0x69 => PrimitiveKind::U8,
 
-        0x70 => PrimitiveType::RChar,
-        0x71 => PrimitiveType::WChar,
-        0x7a => PrimitiveType::RChar16,
-        0x7b => PrimitiveType::RChar32,
+        0x70 => PrimitiveKind::RChar,
+        0x71 => PrimitiveKind::WChar,
+        0x7a => PrimitiveKind::RChar16,
+        0x7b => PrimitiveKind::RChar32,
 
-        0x11 => PrimitiveType::I16,
-        0x21 => PrimitiveType::U16,
-        0x72 => PrimitiveType::I16,
-        0x73 => PrimitiveType::U16,
+        0x11 => PrimitiveKind::I16,
+        0x21 => PrimitiveKind::U16,
+        0x72 => PrimitiveKind::I16,
+        0x73 => PrimitiveKind::U16,
 
-        0x12 => PrimitiveType::I32,
-        0x22 => PrimitiveType::U32,
-        0x74 => PrimitiveType::I32,
-        0x75 => PrimitiveType::U32,
+        0x12 => PrimitiveKind::I32,
+        0x22 => PrimitiveKind::U32,
+        0x74 => PrimitiveKind::I32,
+        0x75 => PrimitiveKind::U32,
 
-        0x13 => PrimitiveType::I64,
-        0x23 => PrimitiveType::U64,
-        0x76 => PrimitiveType::I64,
-        0x77 => PrimitiveType::U64,
+        0x13 => PrimitiveKind::I64,
+        0x23 => PrimitiveKind::U64,
+        0x76 => PrimitiveKind::I64,
+        0x77 => PrimitiveKind::U64,
 
-        0x14 => PrimitiveType::I128,
-        0x24 => PrimitiveType::U128,
-        0x78 => PrimitiveType::I128,
-        0x79 => PrimitiveType::U128,
+        0x14 => PrimitiveKind::I128,
+        0x24 => PrimitiveKind::U128,
+        0x78 => PrimitiveKind::I128,
+        0x79 => PrimitiveKind::U128,
 
-        0x46 => PrimitiveType::F16,
-        0x40 => PrimitiveType::F32,
-        0x45 => PrimitiveType::F32PP,
-        0x44 => PrimitiveType::F48,
-        0x41 => PrimitiveType::F64,
-        0x42 => PrimitiveType::F80,
-        0x43 => PrimitiveType::F128,
+        0x46 => PrimitiveKind::F16,
+        0x40 => PrimitiveKind::F32,
+        0x45 => PrimitiveKind::F32PP,
+        0x44 => PrimitiveKind::F48,
+        0x41 => PrimitiveKind::F64,
+        0x42 => PrimitiveKind::F80,
+        0x43 => PrimitiveKind::F128,
 
-        0x50 => PrimitiveType::Complex32,
-        0x51 => PrimitiveType::Complex64,
-        0x52 => PrimitiveType::Complex80,
-        0x53 => PrimitiveType::Complex128,
+        0x50 => PrimitiveKind::Complex32,
+        0x51 => PrimitiveKind::Complex64,
+        0x52 => PrimitiveKind::Complex80,
+        0x53 => PrimitiveKind::Complex128,
 
-        0x30 => PrimitiveType::Bool8,
-        0x31 => PrimitiveType::Bool16,
-        0x32 => PrimitiveType::Bool32,
-        0x33 => PrimitiveType::Bool64,
+        0x30 => PrimitiveKind::Bool8,
+        0x31 => PrimitiveKind::Bool16,
+        0x32 => PrimitiveKind::Bool32,
+        0x33 => PrimitiveKind::Bool64,
 
         _ => { return Err(Error::TypeNotFound(index)); }
     };
 
-    Ok(TypeData::Primitive{
+    Ok(TypeData::Primitive(PrimitiveType {
+        kind: kind,
         indirection: indirection,
-        primitive_type: primitive_type,
-    })
+    }))
 }

--- a/tests/symbol_table.rs
+++ b/tests/symbol_table.rs
@@ -25,7 +25,7 @@ fn count_symbols() {
         let mut iter = global_symbols.iter();
         while let Some(sym) = iter.next().expect("next symbol") {
             let kind = sym.raw_kind();
-            let mut entry = map.entry(kind).or_insert(0);
+            let entry = map.entry(kind).or_insert(0);
 
             if *entry == 0 && is_fixture {
                 // first symbol of this kind seen

--- a/tests/type_information.rs
+++ b/tests/type_information.rs
@@ -75,19 +75,19 @@ fn find_classes() {
 
             // parse the type record
             match typ.parse() {
-                Ok(pdb::TypeData::Class { name, fields: Some(fields), .. }) => {
+                Ok(pdb::TypeData::Class(pdb::ClassType { name, fields: Some(fields), ..})) => {
                     // this Type describes a class-like type with fields
                     println!("class {} (type {}):", name, typ.type_index());
 
                     // fields is presently a TypeIndex
                     // find and parse the list of fields
                     match type_finder.find(fields).expect("find fields").parse() {
-                        Ok(pdb::TypeData::FieldList { fields, continuation }) => {
-                            for field in fields {
+                        Ok(pdb::TypeData::FieldList(list)) => {
+                            for field in list.fields {
                                 println!("  - {:?}", field);
                             }
 
-                            if let Some(c) = continuation {
+                            if let Some(c) = list.continuation {
                                 println!("TODO: follow to type {}", c);
                             }
                         }
@@ -100,17 +100,17 @@ fn find_classes() {
                         }
                     }
                 },
-                Ok(pdb::TypeData::Enumeration { name, fields, .. }) => {
-                    println!("enum {} (type {}):", name, fields);
+                Ok(pdb::TypeData::Enumeration(data)) => {
+                    println!("enum {} (type {}):", data.name, data.fields);
 
                     // fields is presently a TypeIndex
-                    match type_finder.find(fields).expect("find fields").parse() {
-                        Ok(pdb::TypeData::FieldList { fields, continuation }) => {
-                            for field in fields {
+                    match type_finder.find(data.fields).expect("find fields").parse() {
+                        Ok(pdb::TypeData::FieldList(list)) => {
+                            for field in list.fields {
                                 println!("  - {:?}", field);
                             }
 
-                            if let Some(c) = continuation {
+                            if let Some(c) = list.continuation {
                                 println!("TODO: follow to type {}", c);
                             }
                         }
@@ -123,7 +123,7 @@ fn find_classes() {
                         }
                     }
                 },
-                Ok(pdb::TypeData::FieldList { .. }) => {
+                Ok(pdb::TypeData::FieldList(_)) => {
                     // ignore, since we find these by class
                 }
                 Ok(_) => {


### PR DESCRIPTION
Fixes #1 

I'm not completely convinced this is an improvement, so see what you think. It improves my own code, but I don't think it's improved much of the example code in this crate.

It's added a lot of new exported types, which makes it hard to see the important types in the documentation. Maybe the new types should be kept in submodules? Because I'm lazy, I've switched to using `pub use symbol::*`, along with `pub(crate)` for things that shouldn't be exported. I don't know if this is good style.

Please bikeshed the names. I notice LLVM uses `Record` for its versions of the type records (but not the symbol records).