### PR TITLE
Add support for reading stream names, getting raw streams

### DIFF
--- a/examples/stream_names.rs
+++ b/examples/stream_names.rs
@@ -1,0 +1,29 @@
+extern crate pdb;
+
+use std::env;
+use std::ffi::OsStr;
+use std::io::Write;
+
+fn dump_stream_names(filename: &OsStr) -> pdb::Result<()> {
+    let file = std::fs::File::open(filename)?;
+    let mut pdb = pdb::PDB::open(file)?;
+    let info = pdb.pdb_information()?;
+    let names = info.stream_names()?;
+    println!("index, name");
+    for name in names.iter() {
+        println!("{:5}, {}", name.stream_id, name.name);
+    }
+    Ok(())
+}
+
+fn main() {
+    let filename = env::args_os().nth(1).expect("Missing PDB filename");
+
+    match dump_stream_names(&filename) {
+        Ok(_) => {}
+        Err(e) => {
+            writeln!(&mut std::io::stderr(), "error dumping PDB: {}", e)
+                .expect("stderr write");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod pdbi;
 pub use common::{Error,Result,TypeIndex,RawString,Variant};
 pub use dbi::{DebugInformation, Module, ModuleIter};
 pub use module_info::ModuleInfo;
-pub use pdbi::{PDBInformation};
+pub use pdbi::{NameIter, PDBInformation, StreamName, StreamNames};
 pub use pdb::PDB;
 pub use source::*;
 pub use symbol::{SymbolTable,Symbol,SymbolData,SymbolIter};

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -226,4 +226,31 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
         };
         res
     }
+
+    /// Retrieve a stream by its index to read its contents as bytes.
+    ///
+    /// # Errors
+    ///
+    /// * `Error::StreamNotFound` if the PDB does not contain this module info stream
+    /// * `Error::IoError` if returned by the `Source`
+    /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn test() -> pdb::Result<()> {
+    /// let file = std::fs::File::open("fixtures/self/foo.pdb")?;
+    /// let mut pdb = pdb::PDB::open(file)?;
+    /// // This is the index of the "mystream" stream that was added using pdbstr.exe.
+    /// let s = pdb.raw_stream(208)?;
+    /// let mut buf = s.parse_buffer();
+    /// let len = buf.len();
+    /// let bytes = buf.take(len)?;
+    /// assert_eq!(bytes, b"hello world\n");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn raw_stream(&mut self, stream: u32) -> Result<Stream<'s>> {
+        self.msf.get(stream, None)
+    }
 }

--- a/src/pdbi.rs
+++ b/src/pdbi.rs
@@ -9,32 +9,171 @@ use common::*;
 use msf::*;
 use uuid::Uuid;
 use dbi::HeaderVersion;
+use std::mem;
 
 /// A PDB info stream header parsed from a stream.
-/// Reference:
-/// http://llvm.org/docs/PDB/PdbStream.html
-#[derive(Debug,Copy,Clone)]
-pub struct PDBInformation {
+///
+/// The [PDB information stream][1] contains the GUID and age fields that can be used to
+/// verify that a PDB file matches a specific binary, as well a list of named PDB streams
+/// with their stream indices.
+///
+/// [1]: http://llvm.org/docs/PDB/PdbStream.html
+#[derive(Debug)]
+pub struct PDBInformation<'s> {
+    /// The version of the PDB format in use.
     pub version: HeaderVersion,
+    /// A 32-bit timestamp.
     pub signature: u32,
+    /// The number of times this PDB file has been written.
     pub age: u32,
-    pub guid: Uuid
+    /// A `Uuid` generated when this PDB file was created that should uniquely identify it.
+    pub guid: Uuid,
+    /// The offset of the start of the stream name data within the stream.
+    pub names_offset: usize,
+    /// The size of the stream name data, in bytes.
+    pub names_size: usize,
+    stream: Stream<'s>,
+}
+
+impl<'s> PDBInformation<'s> {
+    /// Get a `StreamNames` object that can be used to iterate over named streams contained
+    /// within the PDB file.
+    ///
+    /// This can be used to look up certain PDB streams by name.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use pdb::FallibleIterator;
+    /// #
+    /// # fn test() -> pdb::Result<()> {
+    /// let file = std::fs::File::open("fixtures/self/foo.pdb")?;
+    /// let mut pdb = pdb::PDB::open(file)?;
+    /// let info = pdb.pdb_information()?;
+    /// let names = info.stream_names()?;
+    /// let mut v: Vec<_> = names.iter().map(|n| n.name.to_string()).collect();
+    /// v.sort();
+    /// assert_eq!(&v, &["/LinkInfo", "/names", "/src/headerblock"]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn stream_names(&self) -> Result<StreamNames> {
+        parse_names(self)
+    }
+}
+
+/// A named stream contained within the PDB file.
+#[derive(Debug)]
+pub struct StreamName<'n> {
+    /// The stream's name.
+    pub name: RawString<'n>,
+    /// The index of this stream.
+    pub stream_id: u32,
+}
+
+/// A list of named streams contained within the PDB file.
+///
+/// Call [`StreamNames::iter`][1] to iterate over the names. The iterator produces [`StreamName`][2]
+/// objects.
+///
+/// [1]: #method.iter
+/// [2]: struct.StreamName.html
+#[derive(Debug)]
+pub struct StreamNames<'s> {
+    buf: ParseBuffer<'s>,
+    /// The list of streams and their names.
+    names: Vec<StreamName<'s>>,
+}
+
+pub type NameIter<'a, 'n> = ::std::slice::Iter<'a, StreamName<'n>>;
+
+impl<'s> StreamNames<'s> {
+    /// Return an iterator over named streams and their stream indices.
+    pub fn iter<'a>(&'a self) -> NameIter<'a,'s> {
+        self.names.iter()
+    }
+}
+
+/// Parse the names map from the PDB info stream `info`.
+///
+/// The names map is part of the PDB info stream that provides a mapping from stream names to
+/// stream indicies. Its [format on disk](1) is somewhat complicated, consisting of a block of data
+/// comprising the names as null-terminated C strings, followed by a map of stream indices
+/// to the offset of their names within the names block.
+///
+/// [The map itself](2) is stored as a 32-bit count of the number of entries, followed by a 32-bit
+/// value that gives the number of bytes taken up by the entries themselves, followed by two sets:
+/// one for names that are present in this PDB, and one for names that have been deleted, followed
+/// by the map entries, each of which is a pair of 32-bit values consisting of an offset into the
+/// names block and a stream ID.
+///
+/// [The two sets](3) are each stored as a [bit array](4), which consists of a 32-bit count, and
+/// then that many 32-bit words containing the bits in the array.
+///
+/// [1]: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/include/nmtni.h#L76
+/// [2]: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/include/map.h#L474
+/// [3]: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/include/iset.h#L62
+/// [4]: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/include/array.h#L209
+fn parse_names<'b, 's: 'b>(info: &'b PDBInformation<'s>) -> Result<StreamNames<'b>> {
+    let mut names = vec![];
+    let buf = {
+        let mut buf = info.stream.parse_buffer();
+        // Seek forward to the name map.
+        buf.take(info.names_offset + info.names_size)?;
+        let count = buf.parse_u32()?;
+        // We don't actually use most of these.
+        let _entries_size = buf.parse_u32()?;
+        let ok_words = buf.parse_u32()?;
+        let _ok_bits = buf.take(ok_words as usize * mem::size_of::<u32>())?;
+        let deleted_words = buf.parse_u32()?;
+        let _deleted_bits = buf.take(deleted_words as usize * mem::size_of::<u32>())?;
+
+        // Skip over the header here.
+        let mut names_reader = info.stream.parse_buffer();
+        names_reader.take(info.names_offset)?;
+        // And take just the name data.
+        let names_buf = names_reader.take(info.names_size)?;
+        for _ in 0..count {
+            let name_offset = buf.parse_u32()? as usize;
+            let stream_id = buf.parse_u32()?;
+            let name = ParseBuffer::from(&names_buf[name_offset..]).parse_cstring()?;
+            names.push(StreamName {
+                name,
+                stream_id,
+            });
+        }
+        names_reader
+    };
+    Ok(StreamNames {
+        buf,
+        names,
+    })
 }
 
 pub fn new_pdb_information(stream: Stream) -> Result<PDBInformation> {
-    let mut buf = stream.parse_buffer();
-
-    let header = PDBInformation {
-        version: From::from(buf.parse_u32()?),
-        signature: buf.parse_u32()?,
-        age: buf.parse_u32()?,
-        guid: Uuid::from_fields(
+    let (version, signature, age, guid, names_size, names_offset) = {
+        let mut buf = stream.parse_buffer();
+        let version = From::from(buf.parse_u32()?);
+        let signature = buf.parse_u32()?;
+        let age = buf.parse_u32()?;
+        let guid = Uuid::from_fields(
             buf.parse_u32()?,
             buf.parse_u16()?,
             buf.parse_u16()?,
             buf.take(8)?
-        ).unwrap()
+            ).unwrap();
+        let names_size = buf.parse_u32()? as usize;
+        let names_offset = buf.pos();
+        (version, signature, age, guid, names_size, names_offset)
     };
 
-    Ok(header)
+    Ok(PDBInformation {
+        version,
+        signature,
+        age,
+        guid,
+        names_size,
+        names_offset,
+        stream,
+    })
 }

--- a/src/pdbi.rs
+++ b/src/pdbi.rs
@@ -53,7 +53,7 @@ impl<'s> PDBInformation<'s> {
     /// let names = info.stream_names()?;
     /// let mut v: Vec<_> = names.iter().map(|n| n.name.to_string()).collect();
     /// v.sort();
-    /// assert_eq!(&v, &["/LinkInfo", "/names", "/src/headerblock"]);
+    /// assert_eq!(&v, &["mystream", "/LinkInfo", "/names", "/src/headerblock"]);
     /// # Ok(())
     /// # }
     /// ```

--- a/tests/pdb_information.rs
+++ b/tests/pdb_information.rs
@@ -10,7 +10,7 @@ fn pdb_info() {
     let mut pdb = pdb::PDB::open(file).expect("opening pdb");
     let pdb_info = pdb.pdb_information().expect("pdb information");
 
-    assert_eq!(pdb_info.age, 1);
+    assert_eq!(pdb_info.age, 2);
     assert_eq!(pdb_info.guid, uuid::Uuid::from_str("2B3C3FA5-5A2E-44B8-8BBA-C3300FF69F62").unwrap());
     assert_eq!(pdb_info.signature, 1484498465);
 }


### PR DESCRIPTION
I've had most of this sitting around on a branch for a while, I just forgot to finish it off and submit it.

The name stream is contained in the PDB information stream. There are a few streams that need to be looked up by name. Confusingly, one of them is named `/names`. That stream contains source file names, so this will be useful for some future changes I hope to write.

The second changeset here allows access to a raw `Stream` by index. Combined with the first patch this allows looking up a named stream and getting its contents. I don't *love* this change, since the `Stream` + `ParseBuffer` API is a little awkward if you're not trying to parse out data structures. Maybe it would be nicer to add a wrapper struct that just contained an `as_bytes()` method to hide all that?

I wanted that API to mimic read functionality of the pdbstr tool, which we use for inserting source server indexing into our PDB files.