### PR TITLE
Initial cut at using scroll+scroll_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,18 +1,3 @@
-[root]
-name = "pdb"
-version = "0.2.0"
-dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [[package]]
 name = "fallible-iterator"
 version = "0.1.3"
@@ -24,12 +9,72 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pdb"
+version = "0.2.0"
+dependencies = [
+ "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scroll"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scroll_derive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum scroll 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66f024a8cc5e456eb870f688dbd899c84f61190c82c7a911e40f926941969074"
+"checksum scroll_derive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1483807a24e8ac4c4726c8b03b367a508ca1407efca8c5748b9ddd9584dbf56"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d0f5103675a280a926ec2f9b7bcc2ef49367df54e8c570c3311fec919f9a8b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 fallible-iterator = "0.1.3"
-byteorder = "1.0.0"
+scroll = { version = "0.9.0", features = ["derive"] }
 uuid = "0.5.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,9 @@
 //! # assert!(test().expect("test") > 2000);
 //! ```
 
-extern crate byteorder;
 extern crate fallible_iterator;
+#[macro_use]
+extern crate scroll;
 extern crate uuid;
 
 // modules

--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -35,13 +35,6 @@ impl Header {
     }
 }
 
-#[derive(Debug)]
-struct BigMSF<'s, S> {
-    header: Header,
-    source: S,
-    stream_table: StreamTable<'s>,
-}
-
 /// Represents a stream table at various stages of access
 #[doc(hidden)]
 #[derive(Debug)]
@@ -58,8 +51,6 @@ enum StreamTable<'s> {
     Available { stream_table_view: Box<SourceView<'s>> }
 }
 
-const BIG_MSF_MAGIC: &'static [u8] = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00";
-
 fn view<'s>(source: &mut Source<'s>, page_list: &PageList) -> Result<Box<SourceView<'s>>> {
     // view it
     let view = source.view(page_list.source_slices())?;
@@ -73,235 +64,249 @@ fn view<'s>(source: &mut Source<'s>, page_list: &PageList) -> Result<Box<SourceV
     Ok(view)
 }
 
-/// The PDB header as stored on disk.
-/// See the Microsoft code for reference: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/msf/msf.cpp#L946
-#[derive(Debug, Pread)]
-#[repr(C, packed)]
-struct RawHeader {
-    magic: [u8; 32],
-    page_size: u32,
-    free_page_map: u32,
-    pages_used: u32,
-    directory_size: u32,
-    _reserved: u32,
-}
+mod big {
+    use super::*;
 
-impl<'s, S: Source<'s>> BigMSF<'s, S> {
-    pub fn new(source: S, header_view: Box<SourceView>) -> Result<BigMSF<'s, S>> {
-        let mut buf = ParseBuffer::from(header_view.as_slice());
-        let header: RawHeader = buf.parse()?;
+    pub const MAGIC: &'static [u8] = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00";
 
-        if header.magic != BIG_MSF_MAGIC {
-            return Err(Error::UnrecognizedFileFormat);
-        }
-
-        if header.page_size.count_ones() != 1 || header.page_size < 0x100
-            || header.page_size > (128 * 0x10000) {
-                return Err(Error::InvalidPageSize(header.page_size));
-            }
-
-        let header_object = Header{
-            page_size: header.page_size as usize,
-            maximum_valid_page_number: header.pages_used,
-        };
-
-        // calculate how many pages are needed to store the stream table
-        let size_of_stream_table_in_pages = header_object.pages_needed_to_store(header.directory_size as usize);
-
-        // now: how many pages are needed to store the list of pages that store the stream table?
-        // each page entry is a u32, so multiply by four
-        let size_of_stream_table_page_list_in_pages = header_object.pages_needed_to_store(size_of_stream_table_in_pages * 4);
-
-        // read the list of stream table page list pages, which immediately follow the header
-        // yes, this is a stupid level of indirection
-        let mut stream_table_page_list_page_list = PageList::new(header_object.page_size);
-        for _ in 0..size_of_stream_table_page_list_in_pages {
-            let n = buf.parse_u32()?;
-            stream_table_page_list_page_list.push(header_object.validate_page_number(n)?);
-        }
-
-        // truncate the stream table location location to the correct size
-        stream_table_page_list_page_list.truncate(size_of_stream_table_in_pages * 4);
-
-        Ok(BigMSF{
-            header: header_object,
-            source: source,
-            stream_table: StreamTable::HeaderOnly {
-                size_in_bytes: header.directory_size as usize,
-                stream_table_location_location: stream_table_page_list_page_list,
-            },
-        })
+    /// The PDB header as stored on disk.
+    /// See the Microsoft code for reference: https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/msf/msf.cpp#L946
+    #[derive(Debug, Pread)]
+    #[repr(C, packed)]
+    struct RawHeader {
+        magic: [u8; 32],
+        page_size: u32,
+        free_page_map: u32,
+        pages_used: u32,
+        directory_size: u32,
+        _reserved: u32,
     }
 
-    fn find_stream_table(&mut self) -> Result<()> {
-        let mut new_stream_table: Option<StreamTable> = None;
-
-        if let StreamTable::HeaderOnly { size_in_bytes, ref stream_table_location_location } = self.stream_table {
-            // the header indicated we need to read size_in_pages page numbers from the
-            // specified PageList.
-
-            // ask to view the location location
-            let location_location = view(&mut self.source, stream_table_location_location)?;
-
-            // build a PageList
-            let mut page_list = PageList::new(self.header.page_size);
-            let mut buf = ParseBuffer::from(location_location.as_slice());
-            while buf.len() > 0 {
-                let n = buf.parse_u32()?;
-                page_list.push(self.header.validate_page_number(n)?);
-            }
-
-            page_list.truncate(size_in_bytes);
-
-            // remember what we learned
-            new_stream_table = Some(StreamTable::TableFound {
-                stream_table_location: page_list,
-            });
-        }
-
-        if let Some(st) = new_stream_table {
-            self.stream_table = st;
-        }
-
-        Ok(())
+    #[derive(Debug)]
+    pub struct BigMSF<'s, S> {
+        header: Header,
+        source: S,
+        stream_table: StreamTable<'s>,
     }
 
-    fn make_stream_table_available(&mut self) -> Result<()> {
-        // do the initial read if we must
-        if let StreamTable::HeaderOnly { .. } = self.stream_table {
-            self.find_stream_table()?;
-        }
+    impl<'s, S: Source<'s>> BigMSF<'s, S> {
+        pub fn new(source: S, header_view: Box<SourceView>) -> Result<BigMSF<'s, S>> {
+            let mut buf = ParseBuffer::from(header_view.as_slice());
+            let header: RawHeader = buf.parse()?;
 
-        // do we need to map the stream table itself?
-        let mut new_stream_table: Option<StreamTable> = None;
-        if let StreamTable::TableFound { ref stream_table_location } = self.stream_table {
-            // yep
-            // ask the source to view it
-            let stream_table_view = view(&mut self.source, stream_table_location)?;
-
-            // done
-            new_stream_table = Some(StreamTable::Available {
-                stream_table_view: stream_table_view,
-            });
-        }
-
-        if let Some(st) = new_stream_table {
-            self.stream_table = st;
-        }
-
-        // stream table is available
-        assert!(match &self.stream_table {
-            &StreamTable::Available { .. } => true,
-            _ => false
-        });
-
-        Ok(())
-    }
-
-    fn look_up_stream(&mut self, stream_number: u32) -> Result<PageList> {
-        // ensure the stream table is available
-        self.make_stream_table_available()?;
-
-        let header = self.header;
-
-        // declare the things we're going to find
-        let bytes_in_stream: u32;
-        let page_list: PageList;
-
-        if let StreamTable::Available { ref stream_table_view } = self.stream_table {
-            let stream_table_slice = stream_table_view.as_slice();
-            let mut stream_table = ParseBuffer::from(stream_table_slice);
-
-            // the stream table is structured as:
-            // stream_count
-            // 0..stream_count: size of stream in bytes (0xffffffff indicating "stream does not exist")
-            // stream 0: PageNumber
-            // stream 1: PageNumber, PageNumber
-            // stream 2: PageNumber, PageNumber, PageNumber, PageNumber, PageNumber
-            // stream 3: PageNumber, PageNumber, PageNumber, PageNumber
-            // (number of pages determined by number of bytes)
-
-            let stream_count = stream_table.parse_u32()?;
-
-            // check if we've already outworn our welcome
-            if stream_number >= stream_count {
-                return Err(Error::StreamNotFound(stream_number))
+            if header.magic != MAGIC {
+                return Err(Error::UnrecognizedFileFormat);
             }
 
-            // we now have {stream_count} u32s describing the length of each stream
-
-            // walk over the streams before the requested stream
-            // we need to pay attention to how big each one is, since their page numbers come
-            // before our page numbers in the stream table
-            let mut page_numbers_to_skip: usize = 0;
-            for _ in 0..stream_number {
-                let bytes = stream_table.parse_u32()?;
-                if bytes == 0xffffffff {
-                    // stream is not present, ergo nothing to skip
-                } else {
-                    page_numbers_to_skip += header.pages_needed_to_store(bytes as usize);
+            if header.page_size.count_ones() != 1 || header.page_size < 0x100
+                || header.page_size > (128 * 0x10000) {
+                    return Err(Error::InvalidPageSize(header.page_size));
                 }
+
+            let header_object = Header{
+                page_size: header.page_size as usize,
+                maximum_valid_page_number: header.pages_used,
+            };
+
+            // calculate how many pages are needed to store the stream table
+            let size_of_stream_table_in_pages = header_object.pages_needed_to_store(header.directory_size as usize);
+
+            // now: how many pages are needed to store the list of pages that store the stream table?
+            // each page entry is a u32, so multiply by four
+            let size_of_stream_table_page_list_in_pages = header_object.pages_needed_to_store(size_of_stream_table_in_pages * 4);
+
+            // read the list of stream table page list pages, which immediately follow the header
+            // yes, this is a stupid level of indirection
+            let mut stream_table_page_list_page_list = PageList::new(header_object.page_size);
+            for _ in 0..size_of_stream_table_page_list_in_pages {
+                let n = buf.parse_u32()?;
+                stream_table_page_list_page_list.push(header_object.validate_page_number(n)?);
             }
 
-            // read our stream's size
-            bytes_in_stream = stream_table.parse_u32()?;
-            if bytes_in_stream == 0xffffffff {
-                return Err(Error::StreamNotFound(stream_number))
-            }
-            let pages_in_stream = header.pages_needed_to_store(bytes_in_stream as usize);
+            // truncate the stream table location location to the correct size
+            stream_table_page_list_page_list.truncate(size_of_stream_table_in_pages * 4);
 
-            // skip the remaining streams' byte counts
-            let _ = stream_table.take((stream_count - stream_number - 1) as usize * 4)?;
-
-            // skip the preceding streams' page numbers
-            let _ = stream_table.take((page_numbers_to_skip as usize) * 4)?;
-
-            // we're now at the list of pages for our stream
-            // accumulate them into a PageList
-            let mut list = PageList::new(header.page_size);
-            for _ in 0..pages_in_stream {
-                let page_number = stream_table.parse_u32()?;
-                list.push(self.header.validate_page_number(page_number)?);
-            }
-
-            // truncate to the size of the stream
-            list.truncate(bytes_in_stream as usize);
-
-            page_list = list;
-        } else {
-            unreachable!();
+            Ok(BigMSF{
+                header: header_object,
+                source: source,
+                stream_table: StreamTable::HeaderOnly {
+                    size_in_bytes: header.directory_size as usize,
+                    stream_table_location_location: stream_table_page_list_page_list,
+                },
+            })
         }
 
-        // done!
-        Ok(page_list)
+        fn find_stream_table(&mut self) -> Result<()> {
+            let mut new_stream_table: Option<StreamTable> = None;
+
+            if let StreamTable::HeaderOnly { size_in_bytes, ref stream_table_location_location } = self.stream_table {
+                // the header indicated we need to read size_in_pages page numbers from the
+                // specified PageList.
+
+                // ask to view the location location
+                let location_location = view(&mut self.source, stream_table_location_location)?;
+
+                // build a PageList
+                let mut page_list = PageList::new(self.header.page_size);
+                let mut buf = ParseBuffer::from(location_location.as_slice());
+                while buf.len() > 0 {
+                    let n = buf.parse_u32()?;
+                    page_list.push(self.header.validate_page_number(n)?);
+                }
+
+                page_list.truncate(size_in_bytes);
+
+                // remember what we learned
+                new_stream_table = Some(StreamTable::TableFound {
+                    stream_table_location: page_list,
+                });
+            }
+
+            if let Some(st) = new_stream_table {
+                self.stream_table = st;
+            }
+
+            Ok(())
+        }
+
+        fn make_stream_table_available(&mut self) -> Result<()> {
+            // do the initial read if we must
+            if let StreamTable::HeaderOnly { .. } = self.stream_table {
+                self.find_stream_table()?;
+            }
+
+            // do we need to map the stream table itself?
+            let mut new_stream_table: Option<StreamTable> = None;
+            if let StreamTable::TableFound { ref stream_table_location } = self.stream_table {
+                // yep
+                // ask the source to view it
+                let stream_table_view = view(&mut self.source, stream_table_location)?;
+
+                // done
+                new_stream_table = Some(StreamTable::Available {
+                    stream_table_view: stream_table_view,
+                });
+            }
+
+            if let Some(st) = new_stream_table {
+                self.stream_table = st;
+            }
+
+            // stream table is available
+            assert!(match &self.stream_table {
+                &StreamTable::Available { .. } => true,
+                _ => false
+            });
+
+            Ok(())
+        }
+
+        fn look_up_stream(&mut self, stream_number: u32) -> Result<PageList> {
+            // ensure the stream table is available
+            self.make_stream_table_available()?;
+
+            let header = self.header;
+
+            // declare the things we're going to find
+            let bytes_in_stream: u32;
+            let page_list: PageList;
+
+            if let StreamTable::Available { ref stream_table_view } = self.stream_table {
+                let stream_table_slice = stream_table_view.as_slice();
+                let mut stream_table = ParseBuffer::from(stream_table_slice);
+
+                // the stream table is structured as:
+                // stream_count
+                // 0..stream_count: size of stream in bytes (0xffffffff indicating "stream does not exist")
+                // stream 0: PageNumber
+                // stream 1: PageNumber, PageNumber
+                // stream 2: PageNumber, PageNumber, PageNumber, PageNumber, PageNumber
+                // stream 3: PageNumber, PageNumber, PageNumber, PageNumber
+                // (number of pages determined by number of bytes)
+
+                let stream_count = stream_table.parse_u32()?;
+
+                // check if we've already outworn our welcome
+                if stream_number >= stream_count {
+                    return Err(Error::StreamNotFound(stream_number))
+                }
+
+                // we now have {stream_count} u32s describing the length of each stream
+
+                // walk over the streams before the requested stream
+                // we need to pay attention to how big each one is, since their page numbers come
+                // before our page numbers in the stream table
+                let mut page_numbers_to_skip: usize = 0;
+                for _ in 0..stream_number {
+                    let bytes = stream_table.parse_u32()?;
+                    if bytes == 0xffffffff {
+                        // stream is not present, ergo nothing to skip
+                    } else {
+                        page_numbers_to_skip += header.pages_needed_to_store(bytes as usize);
+                    }
+                }
+
+                // read our stream's size
+                bytes_in_stream = stream_table.parse_u32()?;
+                if bytes_in_stream == 0xffffffff {
+                    return Err(Error::StreamNotFound(stream_number))
+                }
+                let pages_in_stream = header.pages_needed_to_store(bytes_in_stream as usize);
+
+                // skip the remaining streams' byte counts
+                let _ = stream_table.take((stream_count - stream_number - 1) as usize * 4)?;
+
+                // skip the preceding streams' page numbers
+                let _ = stream_table.take((page_numbers_to_skip as usize) * 4)?;
+
+                // we're now at the list of pages for our stream
+                // accumulate them into a PageList
+                let mut list = PageList::new(header.page_size);
+                for _ in 0..pages_in_stream {
+                    let page_number = stream_table.parse_u32()?;
+                    list.push(self.header.validate_page_number(page_number)?);
+                }
+
+                // truncate to the size of the stream
+                list.truncate(bytes_in_stream as usize);
+
+                page_list = list;
+            } else {
+                unreachable!();
+            }
+
+            // done!
+            Ok(page_list)
+        }
+    }
+
+    impl<'s, S: Source<'s>> MSF<'s, S> for BigMSF<'s, S> {
+        fn get(&mut self, stream_number: u32, limit: Option<usize>) -> Result<Stream<'s>> {
+            // look up the stream
+            let mut page_list = self.look_up_stream(stream_number)?;
+
+            // apply any limits we have
+            if let Some(limit) = limit {
+                page_list.truncate(limit);
+            }
+
+            // now that we know where this stream lives, we can view it
+            let view = view(&mut self.source, &page_list)?;
+
+            // pack it into a Stream
+            let stream = Stream {
+                source_view: view,
+            };
+
+            Ok(stream)
+        }
     }
 }
 
-impl<'s, S: Source<'s>> MSF<'s, S> for BigMSF<'s, S> {
-    fn get(&mut self, stream_number: u32, limit: Option<usize>) -> Result<Stream<'s>> {
-        // look up the stream
-        let mut page_list = self.look_up_stream(stream_number)?;
-
-        // apply any limits we have
-        if let Some(limit) = limit {
-            page_list.truncate(limit);
-        }
-
-        // now that we know where this stream lives, we can view it
-        let view = view(&mut self.source, &page_list)?;
-
-        // pack it into a Stream
-        let stream = Stream {
-            source_view: view,
-        };
-
-        Ok(stream)
-    }
+mod small {
+    pub const MAGIC: &'static [u8] = b"Microsoft C/C++ program database 2.00\r\n\x1a\x4a\x47";
+    // TODO: implement SmallMSF
 }
-
-const SMALL_MSF_MAGIC: &'static [u8] = b"Microsoft C/C++ program database 2.00\r\n\x1a\x4a\x47";
-
-// TODO: implement SmallMSF
 
 /// Represents a single Stream within the multi-stream file.
 #[derive(Debug)]
@@ -334,13 +339,13 @@ pub fn open_msf<'s, S: Source<'s> + 's>(mut source: S) -> Result<Box<MSF<'s, S> 
     let header_view = view(&mut source, &header_location)?;
 
     // see if it's a BigMSF
-    if header_matches(header_view.as_slice(), BIG_MSF_MAGIC) {
+    if header_matches(header_view.as_slice(), big::MAGIC) {
         // claimed!
-        let bigmsf = BigMSF::new(source, header_view)?;
+        let bigmsf = big::BigMSF::new(source, header_view)?;
         return Ok(Box::new(bigmsf))
     }
 
-    if header_matches(header_view.as_slice(), SMALL_MSF_MAGIC) {
+    if header_matches(header_view.as_slice(), small::MAGIC) {
         // sorry
         return Err(Error::UnimplementedFeature("small MSF file format"));
     }


### PR DESCRIPTION
Hey! I got motivated to try out `scroll` so I started taking a crack at fixing https://github.com/willglynn/pdb/issues/10.

This patch only changes over the code in `src/msf/mod.rs`, so it's mostly a wash since that code does a lot of reading individual `u32`s, but it does make reading the PDB header nicer. If you like how this looks I can go through and convert the rest of the crate's I/O to use scroll.

One thought: since we're going to wind up with a bunch of structs that define the on-disk PDB format, should those go in their own module?

cc @m4b 