### PR TITLE
Fix symbol length check.

### DIFF
--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -121,7 +121,7 @@ impl<'t> Symbol<'t> {
             _ => return Err(Error::UnimplementedSymbolKind(kind))
         };
 
-        if self.0.len() < data_length + 2 + 2 {
+        if self.0.len() < data_length + 2 {
             return Err(Error::SymbolTooShort);
         }
 


### PR DESCRIPTION
The length of the symbol only needs to be 2 bytes more than
the length of the field data. The 2 bytes are for the kind.
The first 2 bytes of the symbol containing the length or not
included in the slice of symbol data.