### PR TITLE
Fix PDBInformation GUID endianness

### DIFF
--- a/src/pdbi.rs
+++ b/src/pdbi.rs
@@ -156,12 +156,7 @@ pub fn new_pdb_information(stream: Stream) -> Result<PDBInformation> {
         let version = From::from(buf.parse_u32()?);
         let signature = buf.parse_u32()?;
         let age = buf.parse_u32()?;
-        let guid = Uuid::from_fields(
-            buf.parse_u32()?,
-            buf.parse_u16()?,
-            buf.parse_u16()?,
-            buf.take(8)?
-            ).unwrap();
+        let guid = Uuid::from_bytes(buf.take(16)?).unwrap();
         let names_size = buf.parse_u32()? as usize;
         let names_offset = buf.pos();
         (version, signature, age, guid, names_size, names_offset)

--- a/tests/pdb_information.rs
+++ b/tests/pdb_information.rs
@@ -11,6 +11,6 @@ fn pdb_info() {
     let pdb_info = pdb.pdb_information().expect("pdb information");
 
     assert_eq!(pdb_info.age, 2);
-    assert_eq!(pdb_info.guid, uuid::Uuid::from_str("2B3C3FA5-5A2E-44B8-8BBA-C3300FF69F62").unwrap());
+    assert_eq!(pdb_info.guid, uuid::Uuid::from_str("A53F3C2B-2E5A-B844-8BBA-C3300FF69F62").unwrap());
     assert_eq!(pdb_info.signature, 1484498465);
 }


### PR DESCRIPTION
Fixes #24 

This also updates the test case, based on:

```
$ llvm-pdbutil dump -all fixtures/self/foo.pdb

                          Summary
============================================================
  Block Size: 4096
  Number of blocks: 1107
  Number of streams: 209
  Signature: 1484498465
  Age: 2
  GUID: {A53F3C2B-2E5A-B844-8BBA-C3300FF69F62}
  Features: 0x1
  Has Debug Info: true
  Has Types: true
  Has IDs: true
  Has Globals: true
  Has Publics: true
  Is incrementally linked: true
  Has conflicting types: false
  Is stripped: false
```