### PR TITLE
Add support for module private procedure symbols

### DIFF
--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -23,6 +23,9 @@ fn print_symbol(symbol: &pdb::Symbol) -> pdb::Result<()> {
         pdb::SymbolData::DataSymbol(data) => {
             print_row(data.segment, data.offset, "data", symbol.name()?);
         }
+        pdb::SymbolData::Procedure(data) => {
+            print_row(data.segment, data.offset, "function", symbol.name()?);
+        }
         _ => {
             // ignore everything else
         }


### PR DESCRIPTION
- Add ProcedureSymbol struct used to hold data for
  symbol records with kinds: S_GPROC32, S_GPROC32_ST,
  S_LPROC32, S_LPROC32_ST, S_GPROC32_ID, S_LPROC32_ID,
  S_LPROC32_DPC, S_LPROC32_DPC_ID. These kinds are
  used for module private procedures.
- Add Procedure variant to SymbolData enum
- Add ProcedureFlags struct used to hold data from
  a CV_PROCFLAGS bit field. This is used by
  ProcedureSymbol
- Add support to pdb_symbols example to print names
  of module private procedures
- Add unit tests for parsing a few of the new symbol
  kinds, S_LPROC32 and S_GPROC32