### PR TITLE
Implement OMAP-based address translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 *.iml
 .idea
+
+fixtures/symbol_server/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,7 +1,55 @@
 [[package]]
+name = "MacTypes-sys"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "adler32"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cc"
@@ -14,32 +62,104 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "curl"
-version = "0.4.19"
+name = "cloudabi"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl-sys 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.16"
+name = "core-foundation"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -48,12 +168,162 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-cpupool"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "h2"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.12.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -70,19 +340,151 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libz-sys"
-version = "1.0.25"
+name = "libflate"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime_guess"
+version = "2.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -102,15 +504,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pdb"
 version = "0.2.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -135,9 +606,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -148,6 +760,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "schannel"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +772,11 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scroll"
@@ -176,6 +798,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,15 +832,55 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "socket2"
-version = "0.3.8"
+name = "serde"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "string"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
@@ -207,6 +890,169 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-current-thread"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-executor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-reactor"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tcp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-threadpool"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-timer"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicase"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -220,14 +1066,47 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "want"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -258,38 +1137,146 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
+"checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
+"checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c7c9d851c825e0c033979d4516c9173bc19a78a96eb4d6ae51d4045440eafa16"
-"checksum curl-sys 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca79238a79fb294be6173b4057c95b22a718c94c4e38475d5faa82b8383f3502"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
+"checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+"checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
+"checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
+"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
+"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+"checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum encoding_rs 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0535f350c60aac0b87ccf28319abc749391e912192255b0c00a2c12c6917bd73"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
+"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+"checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
+"checksum http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1a10e5b573b9a0146545010f50772b9e8b1dd0a256564cc4307694c68832a2f5"
+"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
+"checksum hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)" = "fdfa9b401ef6c4229745bb6e9b2529192d07b920eed624cdee2a82348cd550af"
+"checksum hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661"
+"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+"checksum libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "54d1ddf9c52870243c5689d7638d888331c1116aa5b398f3ba1acfa7d8758ca1"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
+"checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
+"checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
+"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
+"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
+"checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f205a95638627fc0d21c53901671b06f439dc2830311ff11ecdff34ae2d839a8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
 "checksum scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
+"checksum security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05"
+"checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
+"checksum serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)" = "9f301d728f2b94c9a7691c90f07b0b4e8a4517181d9461be94c04bddeb4bd850"
+"checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
+"checksum serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "e0500b88064f08bebddd0c0bed39e19f5c567a5f30975bee52b0c0d3e2eeb38c"
+"checksum tokio-current-thread 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "331c8acc267855ec06eb0c94618dcbbfea45bed2d20b77252940095273fb58f6"
+"checksum tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30c6dbf2d1ad1de300b393910e8a3aa272b724a400b6531da03eed99e329fbf0"
+"checksum tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b53aeb9d3f5ccf2ebb29e19788f96987fa1355f8fe45ea193928eaaaf3ae820f"
+"checksum tokio-reactor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "afbcdb0f0d2a1e4c440af82d7bbf0bf91a8a8c0575bcd20c05d15be7e9d3a02f"
+"checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
+"checksum tokio-threadpool 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c3fd86cb15547d02daa2b21aadaf4e37dee3368df38a526178a5afa3c034d2fb"
+"checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
+"checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0238db0c5b605dd1cf51de0f21766f97fba2645897024461d6a00c036819a768"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,35 +1,198 @@
-[root]
-name = "pdb"
-version = "0.2.0"
-dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "byteorder"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "curl"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fallible-iterator"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "getopts"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libz-sys"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pdb"
+version = "0.2.0"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "schannel"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "uuid"
-version = "0.5.0"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
-"checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
-"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
-"checksum uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d0f5103675a280a926ec2f9b7bcc2ef49367df54e8c570c3311fec919f9a8b"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b70fd6394677d3c0e239ff4be6f2b3176e171ffd1c23ffdc541e78dea2b8bb5e"
+"checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
+"checksum fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6034a9c9dfce417c7710128d202eef406878cd2fe294e76e2ee05259c9b042d"
+"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "14ba54ac7d5a4eabd1d5f2c1fdeb7e7c14debfa669d94b983d01b465e767ba9e"
+"checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
+"checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
+"checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ uuid = "0.5.0"
 getopts = "0.2.15"
 
 # for tests/
-curl = "0.4.11"
+reqwest = "0.9.10"
 
 [package.metadata.release]
 pre-release-commit-message = "Release {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-fallible-iterator = "0.1.3"
+fallible-iterator = "0.1.4"
 byteorder = "1.0.0"
 uuid = "0.5.0"
 
 [dev-dependencies]
 # for examples/
-getopts = "0.2"
+getopts = "0.2.15"
 
 [package.metadata.release]
 pre-release-commit-message = "Release {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ uuid = "0.5.0"
 # for examples/
 getopts = "0.2.15"
 
+# for tests/
+curl = "0.4.11"
+
 [package.metadata.release]
 pre-release-commit-message = "Release {{version}}"
 tag-message = "Release {{version}}"

--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -2,7 +2,7 @@ extern crate getopts;
 extern crate pdb;
 
 use getopts::Options;
-use pdb::{FallibleIterator, OriginalSectionOffset};
+use pdb::{FallibleIterator, PdbInternalSectionOffset};
 use std::env;
 use std::io::Write;
 
@@ -11,7 +11,7 @@ fn print_usage(program: &str, opts: Options) {
     print!("{}", opts.usage(&brief));
 }
 
-fn print_row(offset: OriginalSectionOffset, kind: &'static str, name: pdb::RawString<'_>) {
+fn print_row(offset: PdbInternalSectionOffset, kind: &'static str, name: pdb::RawString<'_>) {
     println!("{:x}\t{:x}\t{}\t{}", offset.section, offset.offset, kind, name.to_string());
 }
 

--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -2,7 +2,7 @@ extern crate getopts;
 extern crate pdb;
 
 use getopts::Options;
-use pdb::FallibleIterator;
+use pdb::{FallibleIterator, OriginalSectionOffset};
 use std::env;
 use std::io::Write;
 
@@ -11,20 +11,20 @@ fn print_usage(program: &str, opts: Options) {
     print!("{}", opts.usage(&brief));
 }
 
-fn print_row<'p>(segment: u16, offset: u32, kind: &'static str, name: pdb::RawString<'p>) {
-    println!("{:x}\t{:x}\t{}\t{}", segment, offset, kind, name.to_string());
+fn print_row(offset: OriginalSectionOffset, kind: &'static str, name: pdb::RawString<'_>) {
+    println!("{:x}\t{:x}\t{}\t{}", offset.section, offset.offset, kind, name.to_string());
 }
 
 fn print_symbol(symbol: &pdb::Symbol) -> pdb::Result<()> {
     match symbol.parse()? {
         pdb::SymbolData::PublicSymbol(data) => {
-            print_row(data.segment, data.offset, "function", symbol.name()?);
+            print_row(data.offset, "function", symbol.name()?);
         }
         pdb::SymbolData::DataSymbol(data) => {
-            print_row(data.segment, data.offset, "data", symbol.name()?);
+            print_row(data.offset, "data", symbol.name()?);
         }
         pdb::SymbolData::Procedure(data) => {
-            print_row(data.segment, data.offset, "function", symbol.name()?);
+            print_row(data.offset, "function", symbol.name()?);
         }
         _ => {
             // ignore everything else

--- a/fixtures/symbol_server/README.md
+++ b/fixtures/symbol_server/README.md
@@ -1,0 +1,6 @@
+# `fixtures/symbol_server/`
+
+Microsoft operates a [public symbol server](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols).
+This allows `tests/` to download PDBs at runtime instead of including them in this repository.
+
+As an optimization, `tests/` that download PDBs will cache them in this folder.

--- a/src/common.rs
+++ b/src/common.rs
@@ -177,9 +177,9 @@ impl fmt::Debug for Rva {
 ///
 /// This offset can be converted to an `Rva` to receive the address relative to the entire image.
 /// Note that this offset applies to the actual PE headers. The PDB debug information actually
-/// stores [`OriginalSectionOffsets`].
+/// stores [`PdbInternalSectionOffsets`].
 ///
-/// [`OriginalSectionOffsets`]: struct.OriginalSectionOffset.html
+/// [`PdbInternalSectionOffsets`]: struct.PdbInternalSectionOffset.html
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SectionOffset {
     /// The memory offset relative from the start of the section's memory.
@@ -210,31 +210,31 @@ impl fmt::Debug for SectionOffset {
 /// This instance can be converted into an actual [`Rva`] using [`rva`].
 ///
 /// [`Rva`]: struct.Rva.html
-/// [`rva`]: struct.OriginalRva.html#method.rva
+/// [`rva`]: struct.PdbInternalRva.html#method.rva
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct OriginalRva(pub u32);
+pub struct PdbInternalRva(pub u32);
 
-impl From<u32> for OriginalRva {
+impl From<u32> for PdbInternalRva {
     fn from(addr: u32) -> Self {
-        OriginalRva(addr)
+        PdbInternalRva(addr)
     }
 }
 
-impl From<OriginalRva> for u32 {
-    fn from(addr: OriginalRva) -> Self {
+impl From<PdbInternalRva> for u32 {
+    fn from(addr: PdbInternalRva) -> Self {
         addr.0
     }
 }
 
-impl fmt::Display for OriginalRva {
+impl fmt::Display for PdbInternalRva {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:#08x}", self.0)
     }
 }
 
-impl fmt::Debug for OriginalRva {
+impl fmt::Debug for PdbInternalRva {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "OriginalRva({})", self)
+        write!(f, "PdbInternalRva({})", self)
     }
 }
 
@@ -249,23 +249,23 @@ impl fmt::Debug for OriginalRva {
 /// For binaries and their PDBs that have not been optimized, both address spaces are equal and the
 /// offsets are interchangeable. The conversion operations are cheap no-ops in this case.
 ///
-/// [`rva`]: struct.OriginalSectionOffset.html#method.rva
+/// [`rva`]: struct.PdbInternalSectionOffset.html#method.rva
 /// [`SectionOffset`]: struct.SectionOffset.html
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct OriginalSectionOffset {
+pub struct PdbInternalSectionOffset {
     pub offset: u32,
     pub section: u16,
 }
 
-impl OriginalSectionOffset {
+impl PdbInternalSectionOffset {
     pub fn new(section: u16, offset: u32) -> Self {
-        OriginalSectionOffset { offset, section }
+        PdbInternalSectionOffset { offset, section }
     }
 }
 
-impl fmt::Debug for OriginalSectionOffset {
+impl fmt::Debug for PdbInternalSectionOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("OriginalSectionOffset")
+        f.debug_struct("PdbInternalSectionOffset")
             .field("section", &format!("{:#x}", self.section))
             .field("offset", &format!("{:#08x}", self.offset))
             .finish()

--- a/src/common.rs
+++ b/src/common.rs
@@ -69,6 +69,9 @@ pub enum Error {
     /// Variable-length numeric parsing encountered an unexpected prefix.
     UnexpectedNumericPrefix(u16),
 
+    /// Required mapping for virtual addresses (OMAP) was not found.
+    AddressMapNotFound,
+
     /// A parse error from scroll.
     ScrollError(scroll::Error),
 }
@@ -91,6 +94,7 @@ impl error::Error for Error {
             Error::TypeNotIndexed(_, _) => "Type not indexed",
             Error::UnimplementedTypeKind(_) => "Support for types of this kind is not implemented",
             Error::UnexpectedNumericPrefix(_) => "Variable-length numeric parsing encountered an unexpected prefix",
+            Error::AddressMapNotFound => "Required mapping for virtual addresses (OMAP) was not found",
             Error::ScrollError(ref e) => e.description(),
         }
     }
@@ -110,6 +114,7 @@ impl fmt::Display for Error {
             Error::TypeNotIndexed(type_index, indexed_count) => write!(f, "Type {} not indexed (index covers {})", type_index, indexed_count),
             Error::UnimplementedTypeKind(kind) => write!(f, "Support for types of kind 0x{:04x} is not implemented", kind),
             Error::UnexpectedNumericPrefix(prefix) => write!(f, "Variable-length numeric parsing encountered an unexpected prefix (0x{:04x}", prefix),
+            Error::AddressMapNotFound => write!(f, "Required mapping for virtual addresses (OMAP) was not found"),
             _ => fmt::Debug::fmt(self, f)
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -141,6 +141,137 @@ impl convert::From<scroll::Error> for Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
+/// A Relative Virtual Address as it appears in a PE file.
+///
+/// RVAs are always relative to the image base address, as it is loaded into process memory. This
+/// address is reported by debuggers in stack traces and may refer to symbols or instruction
+/// pointers.
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Rva(pub u32);
+
+impl From<u32> for Rva {
+    fn from(addr: u32) -> Self {
+        Rva(addr)
+    }
+}
+
+impl From<Rva> for u32 {
+    fn from(addr: Rva) -> Self {
+        addr.0
+    }
+}
+
+impl fmt::Display for Rva {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#08x}", self.0)
+    }
+}
+
+impl fmt::Debug for Rva {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Rva({})", self)
+    }
+}
+
+/// An offset relative to a PE section.
+///
+/// This offset can be converted to an `Rva` to receive the address relative to the entire image.
+/// Note that this offset applies to the actual PE headers. The PDB debug information actually
+/// stores [`OriginalSectionOffsets`].
+///
+/// [`OriginalSectionOffsets`]: struct.OriginalSectionOffset.html
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SectionOffset {
+    /// The memory offset relative from the start of the section's memory.
+    pub offset: u32,
+
+    /// The index of the section in the PE's section headers list, incremented by `1`. A value of
+    /// `0` indicates an invalid or missing reference.
+    pub section: u16,
+}
+
+impl SectionOffset {
+    pub fn new(section: u16, offset: u32) -> Self {
+        SectionOffset { offset, section }
+    }
+}
+
+impl fmt::Debug for SectionOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SectionOffset")
+            .field("section", &format!("{:#x}", self.section))
+            .field("offset", &format!("{:#08x}", self.offset))
+            .finish()
+    }
+}
+
+/// A Relative Virtual Address in an unoptimized PE file.
+///
+/// This instance can be converted into an actual [`Rva`] using [`rva`].
+///
+/// [`Rva`]: struct.Rva.html
+/// [`rva`]: struct.OriginalRva.html#method.rva
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OriginalRva(pub u32);
+
+impl From<u32> for OriginalRva {
+    fn from(addr: u32) -> Self {
+        OriginalRva(addr)
+    }
+}
+
+impl From<OriginalRva> for u32 {
+    fn from(addr: OriginalRva) -> Self {
+        addr.0
+    }
+}
+
+impl fmt::Display for OriginalRva {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#08x}", self.0)
+    }
+}
+
+impl fmt::Debug for OriginalRva {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "OriginalRva({})", self)
+    }
+}
+
+/// An offset relative to a PE section in the original unoptimized binary.
+///
+/// For optimized Microsoft binaries, this offset points to a virtual address space before the
+/// rearrangement of sections has been performed. This kind of offset is usually stored in PDB debug
+/// information. It can be converted to an RVA in the transformed address space of the optimized
+/// binary using [`rva`]. Likewise, there is a conversion to [`SectionOffset`] in the actual address
+/// space.
+///
+/// For binaries and their PDBs that have not been optimized, both address spaces are equal and the
+/// offsets are interchangeable. The conversion operations are cheap no-ops in this case.
+///
+/// [`rva`]: struct.OriginalSectionOffset.html#method.rva
+/// [`SectionOffset`]: struct.SectionOffset.html
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OriginalSectionOffset {
+    pub offset: u32,
+    pub section: u16,
+}
+
+impl OriginalSectionOffset {
+    pub fn new(section: u16, offset: u32) -> Self {
+        OriginalSectionOffset { offset, section }
+    }
+}
+
+impl fmt::Debug for OriginalSectionOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("OriginalSectionOffset")
+            .field("section", &format!("{:#x}", self.section))
+            .field("offset", &format!("{:#08x}", self.offset))
+            .finish()
+    }
+}
+
 /// Provides little-endian access to a &[u8].
 #[doc(hidden)]
 #[derive(Debug,Clone)]

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -46,6 +46,7 @@ pub struct DebugInformation<'s> {
     stream: Stream<'s>,
     header: Header,
     header_len: usize,
+    extra_streams: DBIExtraStreams,
 }
 
 impl<'s> DebugInformation<'s> {
@@ -66,10 +67,35 @@ pub fn new_debug_information(stream: Stream) -> Result<DebugInformation> {
         (header, buf.pos())
     };
 
+    let extra_streams = {
+        // calculate the location of the extra stream information
+        let offset = len + (
+            header.module_list_size
+            + header.section_contribution_size
+            + header.section_map_size
+            + header.file_info_size
+            + header.type_server_map_size
+            + header.mfc_type_server_index
+            + header.ec_substream_size
+        ) as usize;
+
+        // seek
+        let mut buf = stream.parse_buffer();
+        buf.take(offset)?;
+
+        // grab that section as bytes
+        let bytes = buf.take(header.debug_header_size as _)?;
+
+        // parse those bytes
+        let mut extra_streams_buf = ParseBuffer::from(bytes);
+        parse_dbi_extra_streams(&mut extra_streams_buf)?
+    };
+
     Ok(DebugInformation{
         stream: stream,
         header: header,
         header_len: len,
+        extra_streams: extra_streams,
     })
 }
 
@@ -349,5 +375,115 @@ impl<'m> FallibleIterator for ModuleIter<'m> {
             module_name,
             object_file_name,
         }))
+    }
+}
+
+
+/// A `DbgDataHdr`, which contains a series of (optional) MSF stream numbers.
+#[derive(Debug, Copy, Clone)]
+struct DBIExtraStreams {
+    // The struct itself is defined at:
+    //    https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/dbi/dbi.h#L250-L274
+    // It's just an array of stream numbers; `u16`s where 0xffff means "no stream".
+    //
+    // The array indices are:
+    //    https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/langapi/include/pdb.h#L439-L449
+    // We'll map those to fields.
+    //
+    // The struct itself can be truncated. This is an internal struct; we'll treat missing fields as
+    // 0xffff even if it's a short read, so long as the short read stops on a u16 boundary.
+    fpo: u16,
+    exception: u16,
+    fixup: u16,
+    omap_to_src: u16,
+    omap_from_src: u16,
+    section_headers: u16,
+    token_rid_map: u16,
+    xdata: u16,
+    pdata: u16,
+    new_fpo: u16,
+    original_section_headers: u16,
+}
+
+fn parse_dbi_extra_streams(buf: &mut ParseBuffer) -> Result<DBIExtraStreams> {
+    // short reads are okay, as are long reads -- this struct is actually an array
+    // what's _not_ okay are
+    if buf.len() % 2 == 1 {
+        return Err(Error::UnimplementedFeature("DbgDataHdr should always be an even number of bytes"))
+    }
+
+    fn eof_to_placeholder_stream(err: Error) -> Result<u16> {
+        match err {
+            Error::UnexpectedEof => Ok(0xffff),
+            other => Err(other)
+        }
+    }
+
+    Ok(DBIExtraStreams {
+        fpo: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        exception: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        fixup: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        omap_to_src: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        omap_from_src: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        section_headers: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        token_rid_map: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        xdata: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        pdata: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        new_fpo: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+        original_section_headers: buf.parse_u16().or_else(eof_to_placeholder_stream)?,
+    })
+}
+
+
+fn optional_stream_number(sn: u16) -> Option<u16> {
+    if sn == 0xffff {
+        None
+    } else {
+        Some(sn)
+    }
+}
+
+impl DBIExtraStreams {
+    pub fn fpo(&self) -> Option<u16> { optional_stream_number(self.fpo) }
+    pub fn exception(&self) -> Option<u16> { optional_stream_number(self.exception) }
+    pub fn fixup(&self) -> Option<u16> { optional_stream_number(self.fixup) }
+    pub fn omap_to_src(&self) -> Option<u16> { optional_stream_number(self.omap_to_src) }
+    pub fn omap_from_src(&self) -> Option<u16> { optional_stream_number(self.omap_from_src) }
+    pub fn section_headers(&self) -> Option<u16> { optional_stream_number(self.section_headers) }
+    pub fn token_rid_map(&self) -> Option<u16> { optional_stream_number(self.token_rid_map) }
+    pub fn xdata(&self) -> Option<u16> { optional_stream_number(self.xdata) }
+    pub fn pdata(&self) -> Option<u16> { optional_stream_number(self.pdata) }
+    pub fn new_fpo(&self) -> Option<u16> { optional_stream_number(self.new_fpo) }
+    pub fn original_section_headers(&self) -> Option<u16> { optional_stream_number(self.original_section_headers) }
+}
+
+#[cfg(test)]
+mod tests {
+    use dbi::*;
+
+    #[test]
+    fn test_dbi_extra_streams() {
+        let bytes = vec![
+            0xff, 0xff,
+            0x01, 0x02,
+            0x03, 0x04,
+            0xff, 0xff,
+            0x05, 0x06
+        ];
+
+        let mut buf = ParseBuffer::from(bytes.as_slice());
+        let extra_streams = parse_dbi_extra_streams(&mut buf).expect("parse");
+
+        // check readback
+        assert_eq!(extra_streams.fpo(), None);
+        assert_eq!(extra_streams.exception(), Some(0x0201));
+        assert_eq!(extra_streams.fixup(), Some(0x0403));
+        assert_eq!(extra_streams.omap_to_src(), None);
+        assert_eq!(extra_streams.omap_from_src(), Some(0x0605));
+
+        // check that short reads => None
+        assert_eq!(extra_streams.section_headers(), None);
+        assert_eq!(extra_streams.token_rid_map(), None);
+        assert_eq!(extra_streams.original_section_headers(), None);
     }
 }

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -53,6 +53,7 @@ impl<'s> DebugInformation<'s> {
     pub fn machine_type(&self) -> Result<MachineType> {
         Ok(self.header.machine_type.into())
     }
+
     /// Returns an iterator that can traverse the modules list in sequential order.
     pub fn modules(&self) -> Result<ModuleIter> {
         let mut buf = self.stream.parse_buffer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,16 @@ mod source;
 mod symbol;
 mod tpi;
 mod pdbi;
-mod pe;
-mod omap;
+
+pub mod pe;
+pub mod omap;
 
 // exports
 pub use common::{Error,Result,TypeIndex,RawString,Variant};
 pub use dbi::{DebugInformation, MachineType, Module, ModuleIter};
 pub use module_info::ModuleInfo;
 pub use pdbi::{NameIter, PDBInformation, StreamName, StreamNames};
-pub use pdb::PDB;
+pub use pdb::{PDB, AddressTranslator};
 pub use source::*;
 pub use symbol::*;
 pub use tpi::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,17 +24,19 @@
 //! let mut pdb = pdb::PDB::open(file)?;
 //!
 //! let symbol_table = pdb.global_symbols()?;
+//! let address_map = pdb.address_map()?;
 //!
 //! # let mut count: usize = 0;
 //! let mut symbols = symbol_table.iter();
 //! while let Some(symbol) = symbols.next()? {
 //!     match symbol.parse() {
-//!     	Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
-//!     		// we found the location of a function!
-//!     		println!("{:x}:{:08x} is {}", data.segment, data.offset, symbol.name()?);
+//!         Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
+//!             // we found the location of a function!
+//!             let rva = data.offset.rva(&address_map).unwrap_or_default();
+//!             println!("{} is {}", rva, symbol.name()?);
 //!             # count += 1;
-//!     	}
-//!     	_ => {}
+//!         }
+//!         _ => {}
 //!     }
 //! }
 //!
@@ -60,18 +62,19 @@ mod symbol;
 mod tpi;
 mod pdbi;
 
-pub mod pe;
 pub mod omap;
+pub mod pe;
 
 // exports
-pub use common::{Error,Result,TypeIndex,RawString,Variant};
+pub use common::{Error, Result, TypeIndex, RawString, Variant, OriginalSectionOffset, OriginalRva, Rva, SectionOffset};
 pub use dbi::{DebugInformation, MachineType, Module, ModuleIter};
 pub use module_info::ModuleInfo;
 pub use pdbi::{NameIter, PDBInformation, StreamName, StreamNames};
-pub use pdb::{PDB, AddressTranslator};
+pub use pdb::PDB;
 pub use source::*;
 pub use symbol::*;
 pub use tpi::*;
+pub use omap::AddressMap;
 
 // re-export FallibleIterator for convenience
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod symbol;
 mod tpi;
 mod pdbi;
 mod pe;
+mod omap;
 
 // exports
 pub use common::{Error,Result,TypeIndex,RawString,Variant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod source;
 mod symbol;
 mod tpi;
 mod pdbi;
+mod pe;
 
 // exports
 pub use common::{Error,Result,TypeIndex,RawString,Variant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!     match symbol.parse() {
 //!         Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
 //!             // we found the location of a function!
-//!             let rva = data.offset.rva(&address_map).unwrap_or_default();
+//!             let rva = data.offset.to_rva(&address_map).unwrap_or_default();
 //!             println!("{} is {}", rva, symbol.name()?);
 //!             # count += 1;
 //!         }
@@ -61,12 +61,11 @@ mod source;
 mod symbol;
 mod tpi;
 mod pdbi;
-
-pub mod omap;
-pub mod pe;
+mod omap;
+mod pe;
 
 // exports
-pub use common::{Error, Result, TypeIndex, RawString, Variant, OriginalSectionOffset, OriginalRva, Rva, SectionOffset};
+pub use common::{Error, Result, TypeIndex, RawString, Variant, PdbInternalSectionOffset, PdbInternalRva, Rva, SectionOffset};
 pub use dbi::{DebugInformation, MachineType, Module, ModuleIter};
 pub use module_info::ModuleInfo;
 pub use pdbi::{NameIter, PDBInformation, StreamName, StreamNames};
@@ -75,6 +74,7 @@ pub use source::*;
 pub use symbol::*;
 pub use tpi::*;
 pub use omap::AddressMap;
+pub use pe::ImageSectionHeader;
 
 // re-export FallibleIterator for convenience
 #[doc(no_inline)]

--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -307,6 +307,11 @@ impl<'s> Stream<'s> {
         let slice = self.source_view.as_slice();
         ParseBuffer::from(slice)
     }
+
+    #[inline]
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.source_view.as_slice()
+    }
 }
 
 /// Provides access to a "multi-stream file", which is the container format used by PDBs.

--- a/src/omap.rs
+++ b/src/omap.rs
@@ -5,95 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-
 //! Utilities for translating addresses between PDB offsets and _Relative Virtual Addresses_ (RVAs).
-//!
-//! # Background
-//!
-//! Addresses in PDBs are stored as offsets into sections of the PE file. The `AddressMap` contains
-//! the PE's section headers to translate between the offsets and virtual addresses relative to the
-//! image base (RVAs).
-//!
-//! Additionally, Microsoft has been reordering the Windows system and application binaries to
-//! optimize them for paging reduction, using a toolset reported to be derived from and/or built on
-//! top of the [Vulcan research project]. Relatively little else is known about the tools or the
-//! methods they use. Looking at Windows system binaries like `ntoskrnl.exe`, it is apparent that
-//! their layout has been rearranged, and their respective symbol files contain _OMAP_ re-mapping
-//! information. The [Microsoft Binary Technologies Projects] may be involved in this.
-//!
-//! The internals of this transformation are not well understood. According to [1997 reference
-//! material]:
-//!
-//! > Yet another form of debug information is relatively new and undocumented, except for a few
-//! > obscure references in `WINNT.H` and the Win32 SDK help. This type of information is known as
-//! > OMAP. Apparently, as part of Microsoft's internal build procedure, small fragments of code in
-//! > EXEs and DLLs are moved around to put the most commonly used code at the beginning of the code
-//! > section. This presumably keeps the process memory working set as small as possible. However,
-//! > when shifting around the blocks of code, the corresponding debug information isn't updated.
-//! > Instead, OMAP information is created. It lets symbol table code translate between the original
-//! > address in a symbol table and the modified address where the variable or line of code really
-//! > exists in memory.
-//!
-//! # Usage
-//!
-//! To aid with translating addresses and offsets, this module exposes `AddressMap`, a helper that
-//! contains all information to apply the correct translation of any kind of address or offset to
-//! another. Due to the rearranging optimizations, there are four types involved:
-//!
-//!  - [`Rva`]: A _Relative Virtual Address_ in the actual binary. This address directly corresponds
-//!    to instruction pointers seen in stack traces and symbol addresses reported by debuggers.
-//!  - [`OriginalRva`]: An RVA as it would have appeared before the optimization. This value does
-//!    not have any practical use, as it never occurs in the PDB or the actual binary.
-//!  - [`SectionOffset`]: An offset into a section of the actual binary. A `section` member of _n_
-//!    refers to section _n - 1_, which makes a section number of _0_ a null pointer.
-//!  - [`OriginalSectionOffset`]: An offset into a section of the original binary. These offsets are
-//!    used throughout the PDB and can be converted to either `SectionOffset`, or directly to `Rva`
-//!    in the actual address space.
-//!
-//! For binaries that have not been optimized that way, the `Original*` values are effectively equal
-//! to their regular counterparts and the conversion between the two are no-ops. Address translation
-//! still has to assume different address spaces, which is why there is no direct conversion without
-//! an `AddressMap`.
-//!
-//! # Example
-//!
-//! ```rust
-//! # use pdb::{Rva, FallibleIterator};
-//! #
-//! # fn test() -> pdb::Result<()> {
-//! # let source = std::fs::File::open("fixtures/self/foo.pdb")?;
-//! let mut pdb = pdb::PDB::open(source)?;
-//!
-//! // Compute the address map once and reuse it
-//! let address_map = pdb.address_map()?;
-//!
-//! # let symbol_table = pdb.global_symbols()?;
-//! # let symbol = symbol_table.iter().next()?.unwrap();
-//! # match symbol.parse() { Ok(pdb::SymbolData::PublicSymbol(pubsym)) => {
-//! // Obtain some section offset, eg from a symbol, and convert it
-//! match pubsym.offset.rva(&address_map) {
-//!     Some(rva) => {
-//!         println!("symbol is at {}", rva);
-//! #       assert_eq!(rva, Rva(26048));
-//!     }
-//!     None => {
-//!         println!("symbol refers to eliminated code");
-//! #       panic!("symbol should exist");
-//!     }
-//! }
-//! # } _ => unreachable!() }
-//! # Ok(())
-//! # }
-//! # test().unwrap()
-//! ```
-//!
-//! [Vulcan research project]: https://research.microsoft.com/pubs/69850/tr-2001-50.pdf
-//! [Microsoft Binary Technologies Projects]: https://microsoft.com/windows/cse/bit_projects.mspx
-//! [1997 reference material]: https://www.microsoft.com/msj/0597/hood0597.aspx
-//! [`Rva`]: ../struct.Rva.html
-//! [`OriginalRva`]: ../struct.OriginalRva.html
-//! [`SectionOffset`]: ../struct.SectionOffset.html
-//! [`OriginalSectionOffset`]: ../struct.OriginalSectionOffset.html
 
 use std::cmp::Ordering;
 use std::mem;
@@ -152,7 +64,7 @@ impl Ord for OMAPRecord {
 ///
 ///  - `omap_from_src`: A mapping from the original address space to the transformed address space
 ///    of an optimized binary. Use `PDB::omap_from_src` to obtain an instance of this OMAP. Also,
-///    `OriginalRva::rva` performs this conversion in a safe manner.
+///    `PdbInternalRva::rva` performs this conversion in a safe manner.
 ///  - `omap_to_src`: A mapping from the transformed address space back into the original address
 ///    space of the unoptimized binary. Use `PDB::omap_to_src` to obtain an instace of this OMAP.
 ///    Also, `Rva::original_rva` performs this conversion in a safe manner.
@@ -234,10 +146,95 @@ impl<'s> OMAPTable<'s> {
 /// A mapping between addresses and offsets used in the PDB and PE file.
 ///
 /// To obtain an instace of this address map, call `PDB::address_map`. It will determine the correct
-/// translation mode and read all internal state from the PDB. For more information on address
-/// translation, see the [module level documentation].
+/// translation mode and read all internal state from the PDB. Then use the conversion methods on
+/// the address and offset types to translate addresses.
 ///
-/// [module level documentation]: ./index.html
+/// # Background
+///
+/// Addresses in PDBs are stored as offsets into sections of the PE file. The `AddressMap` contains
+/// the PE's section headers to translate between the offsets and virtual addresses relative to the
+/// image base (RVAs).
+///
+/// Additionally, Microsoft has been reordering the Windows system and application binaries to
+/// optimize them for paging reduction, using a toolset reported to be derived from and/or built on
+/// top of the [Vulcan research project]. Relatively little else is known about the tools or the
+/// methods they use. Looking at Windows system binaries like `ntoskrnl.exe`, it is apparent that
+/// their layout has been rearranged, and their respective symbol files contain _OMAP_ re-mapping
+/// information. The [Microsoft Binary Technologies Projects] may be involved in this.
+///
+/// The internals of this transformation are not well understood. According to [1997 reference
+/// material]:
+///
+/// > Yet another form of debug information is relatively new and undocumented, except for a few
+/// > obscure references in `WINNT.H` and the Win32 SDK help. This type of information is known as
+/// > OMAP. Apparently, as part of Microsoft's internal build procedure, small fragments of code in
+/// > EXEs and DLLs are moved around to put the most commonly used code at the beginning of the code
+/// > section. This presumably keeps the process memory working set as small as possible. However,
+/// > when shifting around the blocks of code, the corresponding debug information isn't updated.
+/// > Instead, OMAP information is created. It lets symbol table code translate between the original
+/// > address in a symbol table and the modified address where the variable or line of code really
+/// > exists in memory.
+///
+/// # Usage
+///
+/// To aid with translating addresses and offsets, this module exposes `AddressMap`, a helper that
+/// contains all information to apply the correct translation of any kind of address or offset to
+/// another. Due to the rearranging optimizations, there are four types involved:
+///
+///  - [`Rva`]: A _Relative Virtual Address_ in the actual binary. This address directly corresponds
+///    to instruction pointers seen in stack traces and symbol addresses reported by debuggers.
+///  - [`PdbInternalRva`]: An RVA as it would have appeared before the optimization. This value does
+///    not have any practical use, as it never occurs in the PDB or the actual binary.
+///  - [`SectionOffset`]: An offset into a section of the actual binary. A `section` member of _n_
+///    refers to section _n - 1_, which makes a section number of _0_ a null pointer.
+///  - [`PdbInternalSectionOffset`]: An offset into a section of the original binary. These offsets
+///    are used throughout the PDB and can be converted to either `SectionOffset`, or directly to
+///    `Rva` in the actual address space.
+///
+/// For binaries that have not been optimized that way, the `PdbInternal*` values are effectively
+/// equal to their regular counterparts and the conversion between the two are no-ops. Address
+/// translation still has to assume different address spaces, which is why there is no direct
+/// conversion without an `AddressMap`.
+///
+/// # Example
+///
+/// ```rust
+/// # use pdb::{Rva, FallibleIterator};
+/// #
+/// # fn test() -> pdb::Result<()> {
+/// # let source = std::fs::File::open("fixtures/self/foo.pdb")?;
+/// let mut pdb = pdb::PDB::open(source)?;
+///
+/// // Compute the address map once and reuse it
+/// let address_map = pdb.address_map()?;
+///
+/// # let symbol_table = pdb.global_symbols()?;
+/// # let symbol = symbol_table.iter().next()?.unwrap();
+/// # match symbol.parse() { Ok(pdb::SymbolData::PublicSymbol(pubsym)) => {
+/// // Obtain some section offset, eg from a symbol, and convert it
+/// match pubsym.offset.to_rva(&address_map) {
+///     Some(rva) => {
+///         println!("symbol is at {}", rva);
+/// #       assert_eq!(rva, Rva(26048));
+///     }
+///     None => {
+///         println!("symbol refers to eliminated code");
+/// #       panic!("symbol should exist");
+///     }
+/// }
+/// # } _ => unreachable!() }
+/// # Ok(())
+/// # }
+/// # test().unwrap()
+/// ```
+///
+/// [Vulcan research project]: https://research.microsoft.com/pubs/69850/tr-2001-50.pdf
+/// [Microsoft Binary Technologies Projects]: https://microsoft.com/windows/cse/bit_projects.mspx
+/// [1997 reference material]: https://www.microsoft.com/msj/0597/hood0597.aspx
+/// [`Rva`]: struct.Rva.html
+/// [`PdbInternalRva`]: struct.PdbInternalRva.html
+/// [`SectionOffset`]: struct.SectionOffset.html
+/// [`PdbInternalSectionOffset`]: struct.PdbInternalSectionOffset.html
 pub struct AddressMap<'s> {
     pub(crate) original_sections: Vec<ImageSectionHeader>,
     pub(crate) transformed_sections: Option<Vec<ImageSectionHeader>>,
@@ -264,14 +261,14 @@ fn get_virtual_address(sections: &[ImageSectionHeader], section: u16, offset: u3
 }
 
 impl Rva {
-    pub fn original_rva(self, translator: &AddressMap) -> Option<OriginalRva> {
+    pub fn to_internal_rva(self, translator: &AddressMap) -> Option<PdbInternalRva> {
         match translator.transformed_to_original {
-            Some(ref omap) => omap.lookup(self.0).map(OriginalRva),
-            None => Some(OriginalRva(self.0)),
+            Some(ref omap) => omap.lookup(self.0).map(PdbInternalRva),
+            None => Some(PdbInternalRva(self.0)),
         }
     }
 
-    pub fn section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
+    pub fn to_section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
         let (section, offset) = match translator.transformed_sections {
             Some(ref sections) => get_section_offset(sections, self.0)?,
             None => get_section_offset(&translator.original_sections, self.0)?,
@@ -280,31 +277,31 @@ impl Rva {
         Some(SectionOffset { section, offset })
     }
 
-    pub fn original_offset(self, translator: &AddressMap) -> Option<OriginalSectionOffset> {
-        self.original_rva(translator)?.original_offset(translator)
+    pub fn to_internal_offset(self, translator: &AddressMap) -> Option<PdbInternalSectionOffset> {
+        self.to_internal_rva(translator)?.to_internal_offset(translator)
     }
 }
 
-impl OriginalRva {
-    pub fn rva(self, translator: &AddressMap) -> Option<Rva> {
+impl PdbInternalRva {
+    pub fn to_rva(self, translator: &AddressMap) -> Option<Rva> {
         match translator.original_to_transformed {
             Some(ref omap) => omap.lookup(self.0).map(Rva),
             None => Some(Rva(self.0)),
         }
     }
 
-    pub fn section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
-        self.rva(translator)?.section_offset(translator)
+    pub fn to_section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
+        self.to_rva(translator)?.to_section_offset(translator)
     }
 
-    pub fn original_offset(self, translator: &AddressMap) -> Option<OriginalSectionOffset> {
+    pub fn to_internal_offset(self, translator: &AddressMap) -> Option<PdbInternalSectionOffset> {
         let (section, offset) = get_section_offset(&translator.original_sections, self.0)?;
-        Some(OriginalSectionOffset { section, offset })
+        Some(PdbInternalSectionOffset { section, offset })
     }
 }
 
 impl SectionOffset {
-    pub fn rva(self, translator: &AddressMap) -> Option<Rva> {
+    pub fn to_rva(self, translator: &AddressMap) -> Option<Rva> {
         let address = match translator.transformed_sections {
             Some(ref sections) => get_virtual_address(sections, self.section, self.offset)?,
             None => get_virtual_address(&translator.original_sections, self.section, self.offset)?,
@@ -313,38 +310,38 @@ impl SectionOffset {
         Some(Rva(address))
     }
 
-    pub fn original_rva(self, translator: &AddressMap) -> Option<OriginalRva> {
-        self.rva(translator)?.original_rva(translator)
+    pub fn to_internal_rva(self, translator: &AddressMap) -> Option<PdbInternalRva> {
+        self.to_rva(translator)?.to_internal_rva(translator)
     }
 
-    pub fn original_offset(self, translator: &AddressMap) -> Option<OriginalSectionOffset> {
+    pub fn to_internal_offset(self, translator: &AddressMap) -> Option<PdbInternalSectionOffset> {
         if translator.transformed_sections.is_none() {
             // Fast path to avoid section table lookups
             let SectionOffset { section, offset } = self;
-            return Some(OriginalSectionOffset { section, offset });
+            return Some(PdbInternalSectionOffset { section, offset });
         }
 
-        self.original_rva(translator)?.original_offset(translator)
+        self.to_internal_rva(translator)?.to_internal_offset(translator)
     }
 }
 
-impl OriginalSectionOffset {
-    pub fn rva(self, translator: &AddressMap) -> Option<Rva> {
-        self.original_rva(translator)?.rva(translator)
+impl PdbInternalSectionOffset {
+    pub fn to_rva(self, translator: &AddressMap) -> Option<Rva> {
+        self.to_internal_rva(translator)?.to_rva(translator)
     }
 
-    pub fn original_rva(self, translator: &AddressMap) -> Option<OriginalRva> {
+    pub fn to_internal_rva(self, translator: &AddressMap) -> Option<PdbInternalRva> {
         get_virtual_address(&translator.original_sections, self.section, self.offset)
-            .map(OriginalRva)
+            .map(PdbInternalRva)
     }
 
-    pub fn section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
+    pub fn to_section_offset(self, translator: &AddressMap) -> Option<SectionOffset> {
         if translator.transformed_sections.is_none() {
             // Fast path to avoid section table lookups
-            let OriginalSectionOffset { section, offset } = self;
+            let PdbInternalSectionOffset { section, offset } = self;
             return Some(SectionOffset { section, offset });
         }
 
-        self.rva(translator)?.section_offset(translator)
+        self.to_rva(translator)?.to_section_offset(translator)
     }
 }

--- a/src/omap.rs
+++ b/src/omap.rs
@@ -11,8 +11,6 @@ use std::cmp::Ordering;
 use std::mem;
 use std::slice;
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use common::*;
 use msf::Stream;
 use pe::ImageSectionHeader;
@@ -24,35 +22,35 @@ use pe::ImageSectionHeader;
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct OMAPRecord {
-    source_address: [u8; 4],
-    target_address: [u8; 4],
+    source_address: u32,
+    target_address: u32,
 }
 
 impl OMAPRecord {
     /// Returns the address in the source space.
     #[inline]
     pub fn source_address(self) -> u32 {
-        LittleEndian::read_u32(&self.source_address)
+        u32::from_le(self.source_address)
     }
 
     /// Returns the start of the mapped portion in the target address space.
     #[inline]
     pub fn target_address(self) -> u32 {
-        LittleEndian::read_u32(&self.target_address)
+        u32::from_le(self.target_address)
     }
 }
 
 impl PartialOrd for OMAPRecord {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.source_address.partial_cmp(&other.source_address)
+        self.source_address().partial_cmp(&other.source_address())
     }
 }
 
 impl Ord for OMAPRecord {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.source_address.cmp(&other.source_address)
+        self.source_address().cmp(&other.source_address())
     }
 }
 

--- a/src/omap.rs
+++ b/src/omap.rs
@@ -1,0 +1,145 @@
+// Copyright 2018 pdb Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use common::*;
+use byteorder::{ByteOrder,LittleEndian,ReadBytesExt};
+use msf::Stream;
+use std::cmp::Ordering;
+
+/// PDBs can contain OMAP tables, which translate relative virtual addresses (RVAs) from one address
+/// space into another.
+///
+/// How can executables end up in a situation needing such translation? This is not well understood,
+/// but according to [1997 reference material](https://www.microsoft.com/msj/0597/hood0597.aspx):
+///
+/// > Yet another form of debug information is relatively new and undocumented, except for a few
+/// > obscure references in `WINNT.H` and the Win32 SDK help. This type of information is known as
+/// > OMAP. Apparently, as part of Microsoft's internal build procedure, small fragments of code in
+/// > EXEs and DLLs are moved around to put the most commonly used code at the beginning of the code
+/// > section. This presumably keeps the process memory working set as small as possible. However,
+/// > when shifting around the blocks of code, the corresponding debug information isn't updated.
+/// > Instead, OMAP information is created. It lets symbol table code translate between the original
+/// > address in a symbol table and the modified address where the variable or line of code really
+/// > exists in memory.
+///
+/// Normal build processes build and link an executable, create a corresponding PDB, and that's the
+/// end of it. Executable addresses are PDB addresses and vice-versa.
+///
+/// However: Microsoft uses unknown tools to subsequently rearrange certain linked executables. A
+/// naïve and unsuspecting user would imagine such tools would additionally rearrange the PDB, but
+/// no. Instead, these tools leave PDB internals alone, store copies of both the old _and_ the new
+/// executable section headers, generate both a "PDB to executable" OMAP table and an "executable to
+/// PDB" OMAP table, and require the user to reference these tables whenever appropriate.
+///
+/// # Structure
+///
+/// OMAP tables are dense arrays, sequentially storing records of the form:
+///
+/// ```
+/// struct Record {
+///     source_address: u32,
+///     target_address: u32
+/// }
+/// ```
+///
+/// Each table is sorted by source address.
+///
+/// As a (potentially) special case, `target_address` can be zero, which seems to indicate that the
+/// `source_address` does not exist in the target address space. However, zero may not be a
+/// strictly invalid address, as RVA zero points to the PE header.
+///
+/// Each record applies to a range of addresses: i.e. record N indicates that addresses in the
+/// half-open interval [ `record[n].source_address`, `record[n+1].source_address` ) were relocated
+/// to a starting address of `record[n].target_address`. If `target_address` is zero, the `lookup()`
+/// will return zero, since this seems more generally correct than treating it as an offset.
+///
+/// Given that the table is sorted, lookups by source address can be efficiently serviced using a
+/// binary search directly against the underlying data without secondary data structures. This is
+/// not the most cache efficient data structure (especially given that half of each cache line is
+/// storing target addresses), but given that OMAP tables are an uncommon PDBs feature, the obvious
+/// binary search implementation seems appropriate.
+#[derive(Debug)]
+pub struct OMAPTable<'s> {
+    stream: Stream<'s>,
+}
+
+impl<'s> OMAPTable<'s> {
+    pub fn new(stream: Stream<'s>) -> Result<OMAPTable> {
+        if stream.as_slice().len() % 8 != 0 {
+            Err(Error::UnimplementedFeature("OMAP tables must be a multiple of the record size"))
+        } else {
+            Ok(OMAPTable{
+                stream
+            })
+        }
+    }
+
+    #[inline]
+    fn records(&self) -> usize {
+        self.stream.as_slice().len() / 8
+    }
+
+    #[inline]
+    fn read_source_address(&self, n: usize) -> u32 {
+        let bytes = self.stream.as_slice();
+        let offset = n * 8;
+        LittleEndian::read_u32(&bytes[offset..offset+4])
+    }
+
+    #[inline]
+    fn read_target_address(&self, n: usize) -> u32 {
+        let bytes = self.stream.as_slice();
+        let offset = n * 8 + 4;
+        LittleEndian::read_u32(&bytes[offset..offset+4])
+    }
+
+    /// Look up `source_address` to yield a target address.
+    ///
+    /// Note that `lookup()` can return zero, which (probably) means that `source_address` does not
+    /// exist in the target address space. This is not a lookup failure per sé, so it's not a
+    /// `Result::Error`, and zero _is_ a valid address, so it's not an `Option::None`. It's just
+    /// zero.
+    pub fn lookup(&self, source_address: u32) -> u32 {
+        // We want to search using Price Is Right rules: closest without going over wins.
+        let n = {
+            let mut size = self.records();
+            let mut left = 0usize;
+            while size > 1 {
+                size /= 2;
+                let center = left + size;
+                let center_address = self.read_source_address(center);
+                match center_address.cmp(&source_address) {
+                    Ordering::Less => {
+                        // go right
+                        left = center;
+                    },
+                    Ordering::Greater => {
+                        // go left
+                        left = left;
+                    },
+                    Ordering::Equal => {
+                        // exact match
+                        left = center;
+                        break;
+                    }
+                };
+            }
+            left
+        };
+
+        let record_source_address = self.read_source_address(n);
+        let record_target_address = self.read_target_address(n);
+
+        assert!(record_source_address <= source_address);
+
+        if record_target_address == 0 {
+            0
+        } else {
+            (source_address - record_source_address) + record_target_address
+        }
+    }
+}

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -473,10 +473,6 @@ pub struct AddressTranslator<'s> {
 
 impl<'s> AddressTranslator<'s> {
     /// Lookup an address relative to the `image_base` from a segment and offset.
-    ///
-    /// An RVA of `0` may either indicate a location that does not exist in the original address
-    /// space, a reference to a non-existent section, or simply the start of the image. Thus, take
-    /// special care when zero is returned from this function.
     pub fn to_rva(&self, segment: u16, offset: u32) -> Option<u32> {
         if segment == 0 {
             return None;

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -334,7 +334,7 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
         };
 
         let stream = self.msf.get(stream_number as u32, None)?;
-        let table = OMAPTable::new(stream)?;
+        let table = OMAPTable::parse(stream)?;
         Ok(Some(table))
     }
 
@@ -365,7 +365,7 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
         };
 
         let stream = self.msf.get(stream_number as u32, None)?;
-        let table = OMAPTable::new(stream)?;
+        let table = OMAPTable::parse(stream)?;
         Ok(Some(table))
     }
 
@@ -466,20 +466,20 @@ impl<'s> AddressTranslator<'s> {
     /// An RVA of `0` may either indicate a location that does not exist in the original address
     /// space, a reference to a non-existent section, or simply the start of the image. Thus, take
     /// special care when zero is returned from this function.
-    pub fn to_rva(&self, segment: u16, offset: u32) -> u32 {
+    pub fn to_rva(&self, segment: u16, offset: u32) -> Option<u32> {
         if segment == 0 {
-            return 0;
+            return None;
         }
 
         let section = match self.sections.get(segment as usize - 1) {
             Some(section) => section,
-            None => return 0,
+            None => return None,
         };
 
         let address = section.virtual_address + offset;
         match self.omap {
             Some(ref omap) => omap.lookup(address),
-            None => address,
+            None => Some(address),
         }
     }
 }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1,0 +1,115 @@
+// Copyright 2018 pdb Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// PDBs contain PE section headers in one or two streams. `pdb::pe` is responsible for parsing them.
+
+use common::*;
+
+/// A PE `IMAGE_SECTION_HEADER`, as described in [the Microsoft documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx).
+#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+pub struct ImageSectionHeader {
+    /// An 8-byte, null-padded UTF-8 string. There is no terminating null character if the string is
+    /// exactly eight characters long. For longer names, this member contains a forward slash (`/`)
+    /// followed by an ASCII representation of a decimal number that is an offset into the string
+    /// table. Executable images do not use a string table and do not support section names longer
+    /// than eight characters.
+    pub name: [u8; 8],
+
+    /// The file address.
+    pub physical_address: u32,
+
+    /// The address of the first byte of the section when loaded into memory, relative to the image
+    /// base. For object files, this is the address of the first byte before relocation is applied.
+    pub virtual_address: u32,
+
+    /// The size of the initialized data on disk, in bytes. This value must be a multiple of the
+    /// `FileAlignment` member of the `IMAGE_OPTIONAL_HEADER` structure. If this value is less than
+    /// the `VirtualSize` member, the remainder of the section is filled with zeroes. If the section
+    /// contains only uninitialized data, the member is zero.
+    pub size_of_raw_data: u32,
+
+    /// A file pointer to the first page within the COFF file. This value must be a multiple of the
+    /// `FileAlignment` member of the `IMAGE_OPTIONAL_HEADER` structure. If a section contains only
+    /// uninitialized data, set this member is zero.
+    pub pointer_to_raw_data: u32,
+
+    /// A file pointer to the beginning of the relocation entries for the section. If there are no
+    /// relocations, this value is zero.
+    pub pointer_to_relocations: u32,
+
+    /// A file pointer to the beginning of the line-number entries for the section. If there are no
+    /// COFF line numbers, this value is zero.
+    pub pointer_to_line_numbers: u32,
+
+    /// The number of relocation entries for the section. This value is zero for executable images.
+    pub number_of_relocations: u16,
+
+    /// The number of line-number entries for the section.
+    pub number_of_line_numbers: u16,
+
+    /// The characteristics of the image.
+    pub characteristics: u32,
+}
+
+impl ImageSectionHeader {
+    pub fn parse(parse_buffer: &mut ParseBuffer) -> Result<Self> {
+        let name_bytes = parse_buffer.take(8)?;
+
+        Ok(ImageSectionHeader{
+            name: [
+                name_bytes[0], name_bytes[1], name_bytes[2], name_bytes[3],
+                name_bytes[4], name_bytes[5], name_bytes[6], name_bytes[7]
+            ],
+            physical_address: parse_buffer.parse_u32()?,
+            virtual_address: parse_buffer.parse_u32()?,
+            size_of_raw_data: parse_buffer.parse_u32()?,
+            pointer_to_raw_data: parse_buffer.parse_u32()?,
+            pointer_to_relocations: parse_buffer.parse_u32()?,
+            pointer_to_line_numbers: parse_buffer.parse_u32()?,
+            number_of_relocations: parse_buffer.parse_u16()?,
+            number_of_line_numbers: parse_buffer.parse_u16()?,
+            characteristics: parse_buffer.parse_u32()?,
+        })
+    }
+
+    pub fn name(&self) -> RawString {
+        let first_nul = self.name.iter().position(|ch| *ch == 0);
+        let name_bytes = &self.name[0..first_nul.unwrap_or(self.name.len())];
+        RawString::from(name_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_section_header() {
+        let bytes: Vec<u8> = vec![
+            0x2E, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00,
+            0x48, 0x35, 0x09, 0x00, 0x00, 0xD0, 0x1E, 0x00,
+            0x00, 0xFE, 0x00, 0x00, 0x00, 0xA2, 0x1E, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0xC8
+        ];
+
+        let mut parse_buffer = ParseBuffer::from(bytes.as_slice());
+
+        let ish = ImageSectionHeader::parse(&mut parse_buffer).expect("parse");
+        assert_eq!(&ish.name, b".data\0\0\0");
+        assert_eq!(ish.name(), RawString::from(".data"));
+        assert_eq!(ish.physical_address, 0x93548);
+        assert_eq!(ish.virtual_address, 0x1ed000);
+        assert_eq!(ish.size_of_raw_data, 0xfe00);
+        assert_eq!(ish.pointer_to_raw_data, 0x1ea200);
+        assert_eq!(ish.pointer_to_relocations, 0);
+        assert_eq!(ish.pointer_to_line_numbers, 0);
+        assert_eq!(ish.number_of_relocations, 0);
+        assert_eq!(ish.number_of_line_numbers, 0);
+        assert_eq!(ish.characteristics, 0xc8000040);
+    }
+}

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -8,7 +8,7 @@
 // PDBs contain PE section headers in one or two streams. `pdb::pe` is responsible for parsing them.
 
 use common::*;
-use std::fmt::{self,Debug,DebugStruct};
+use std::fmt::{self, Debug};
 
 /// A PE `IMAGE_SECTION_HEADER`, as described in [the Microsoft documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx).
 #[derive(Copy,Clone,PartialEq,Eq)]

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+//! Definitions for PE headers contained in PDBs.
+
 // PDBs contain PE section headers in one or two streams. `pdb::pe` is responsible for parsing them.
 
 use common::*;

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -39,7 +39,7 @@ use self::constants::*;
 ///     match symbol.parse() {
 ///         Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
 ///             // we found the location of a function!
-///             let rva = data.offset.rva(&address_map).unwrap_or_default();
+///             let rva = data.offset.to_rva(&address_map).unwrap_or_default();
 ///             println!("{} is {}", rva, symbol.name()?);
 ///             # count += 1;
 ///         }
@@ -210,7 +210,7 @@ fn parse_symbol_data(kind: u16, data: &[u8]) -> Result<SymbolData> {
                 function:   flags & CVPSF_FUNCTION != 0,
                 managed:    flags & CVPSF_MANAGED != 0,
                 msil:       flags & CVPSF_MSIL != 0,
-                offset: OriginalSectionOffset {
+                offset: PdbInternalSectionOffset {
                     offset:     buf.parse_u32()?,
                     section:    buf.parse_u16()?,
                 },
@@ -225,7 +225,7 @@ fn parse_symbol_data(kind: u16, data: &[u8]) -> Result<SymbolData> {
                 global: match kind { S_GDATA32 | S_GDATA32_ST | S_GMANDATA | S_GMANDATA_ST => true, _ => false },
                 managed: match kind { S_LMANDATA | S_LMANDATA_ST | S_GMANDATA | S_GMANDATA_ST => true, _ => false },
                 type_index: buf.parse_u32()?,
-                offset: OriginalSectionOffset {
+                offset: PdbInternalSectionOffset {
                     offset:     buf.parse_u32()?,
                     section:    buf.parse_u16()?,
                 },
@@ -276,7 +276,7 @@ fn parse_symbol_data(kind: u16, data: &[u8]) -> Result<SymbolData> {
             Ok(SymbolData::ThreadStorage(ThreadStorageSymbol {
                 global: match kind { S_GTHREAD32 | S_GTHREAD32_ST => true, _ => false },
                 type_index: buf.parse_u32()?,
-                offset: OriginalSectionOffset {
+                offset: PdbInternalSectionOffset {
                     offset:     buf.parse_u32()?,
                     section:    buf.parse_u16()?,
                 },
@@ -298,7 +298,7 @@ fn parse_symbol_data(kind: u16, data: &[u8]) -> Result<SymbolData> {
                 dbg_start_offset: buf.parse_u32()?,
                 dbg_end_offset: buf.parse_u32()?,
                 type_index: buf.parse_u32()?,
-                offset: OriginalSectionOffset {
+                offset: PdbInternalSectionOffset {
                     offset:     buf.parse_u32()?,
                     section:    buf.parse_u16()?,
                 },
@@ -387,7 +387,7 @@ pub struct PublicSymbol {
     pub function: bool,
     pub managed: bool,
     pub msil: bool,
-    pub offset: OriginalSectionOffset,
+    pub offset: PdbInternalSectionOffset,
 }
 
 /// The information parsed from a symbol record with kind
@@ -398,7 +398,7 @@ pub struct DataSymbol {
     pub global: bool,
     pub managed: bool,
     pub type_index: TypeIndex,
-    pub offset: OriginalSectionOffset,
+    pub offset: PdbInternalSectionOffset,
 }
 
 /// The information parsed from a symbol record with kind
@@ -446,7 +446,7 @@ pub struct UserDefinedTypeSymbol {
 pub struct ThreadStorageSymbol {
     pub global: bool,
     pub type_index: TypeIndex,
-    pub offset: OriginalSectionOffset,
+    pub offset: PdbInternalSectionOffset,
 }
 
 // CV_PROCFLAGS:
@@ -500,7 +500,7 @@ pub struct ProcedureSymbol {
     pub dbg_start_offset: u32,
     pub dbg_end_offset: u32,
     pub type_index: TypeIndex,
-    pub offset: OriginalSectionOffset,
+    pub offset: PdbInternalSectionOffset,
     pub flags: ProcedureFlags
 }
 
@@ -591,7 +591,7 @@ mod tests {
             let buf = &[14, 17, 2, 0, 0, 0, 192, 85, 0, 0, 1, 0, 95, 95, 108, 111, 99, 97, 108, 95, 115, 116, 100, 105, 111, 95, 112, 114, 105, 110, 116, 102, 95, 111, 112, 116, 105, 111, 110, 115, 0, 0];
             let (symbol, data, name) = parse(buf).expect("parse");
             assert_eq!(symbol.raw_kind(), 0x110e);
-            assert_eq!(data, SymbolData::PublicSymbol(PublicSymbol { code: false, function: true, managed: false, msil: false, offset: OriginalSectionOffset { offset: 21952, section: 1 } }));
+            assert_eq!(data, SymbolData::PublicSymbol(PublicSymbol { code: false, function: true, managed: false, msil: false, offset: PdbInternalSectionOffset { offset: 21952, section: 1 } }));
             assert_eq!(name, "__local_stdio_printf_options");
         }
 
@@ -627,7 +627,7 @@ mod tests {
             let buf = &[13, 17, 116, 0, 0, 0, 16, 0, 0, 0, 3, 0, 95, 95, 105, 115, 97, 95, 97, 118, 97, 105, 108, 97, 98, 108, 101, 0, 0, 0];
             let (symbol, data, name) = parse(buf).expect("parse");
             assert_eq!(symbol.raw_kind(), 0x110d);
-            assert_eq!(data, SymbolData::DataSymbol(DataSymbol { global: true, managed: false, type_index: 116, offset: OriginalSectionOffset { offset: 16, section: 3 } }));
+            assert_eq!(data, SymbolData::DataSymbol(DataSymbol { global: true, managed: false, type_index: 116, offset: PdbInternalSectionOffset { offset: 16, section: 3 } }));
             assert_eq!(name, "__isa_available");
         }
 
@@ -636,7 +636,7 @@ mod tests {
             let buf = &[12, 17, 32, 0, 0, 0, 240, 36, 1, 0, 2, 0, 36, 120, 100, 97, 116, 97, 115, 121, 109, 0];
             let (symbol, data, name) = parse(buf).expect("parse");
             assert_eq!(symbol.raw_kind(), 0x110c);
-            assert_eq!(data, SymbolData::DataSymbol(DataSymbol { global: false, managed: false, type_index: 32, offset: OriginalSectionOffset { offset: 74992, section: 2 } }));
+            assert_eq!(data, SymbolData::DataSymbol(DataSymbol { global: false, managed: false, type_index: 32, offset: PdbInternalSectionOffset { offset: 74992, section: 2 } }));
             assert_eq!(name, "$xdatasym");
         }
 
@@ -654,7 +654,7 @@ mod tests {
             let buf = &[16, 17, 0, 0, 0, 0, 48, 2, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 7, 16, 0, 0, 64, 85, 0, 0, 1, 0, 0, 66, 97, 122, 58, 58, 102, 95, 112, 114, 111, 116, 101, 99, 116, 101, 100, 0];
             let (symbol, data, name) = parse(buf).expect("parse");
             assert_eq!(symbol.raw_kind(), 0x1110);
-            assert_eq!(data, SymbolData::Procedure(ProcedureSymbol { global: true, parent: 0, end: 560, next: 0, len: 6, dbg_start_offset: 5, dbg_end_offset: 5, type_index: 4103, offset: OriginalSectionOffset { offset: 21824, section: 1 }, flags: ProcedureFlags { nofpo: false, int: false, far: false, never: false, notreached: false, cust_call: false, noinline: false, optdbginfo: false } }));
+            assert_eq!(data, SymbolData::Procedure(ProcedureSymbol { global: true, parent: 0, end: 560, next: 0, len: 6, dbg_start_offset: 5, dbg_end_offset: 5, type_index: 4103, offset: PdbInternalSectionOffset { offset: 21824, section: 1 }, flags: ProcedureFlags { nofpo: false, int: false, far: false, never: false, notreached: false, cust_call: false, noinline: false, optdbginfo: false } }));
             assert_eq!(name, "Baz::f_protected");
         }
 
@@ -663,7 +663,7 @@ mod tests {
             let buf = &[15, 17, 0, 0, 0, 0, 156, 1, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 4, 0, 0, 0, 9, 0, 0, 0, 128, 16, 0, 0, 196, 87, 0, 0, 1, 0, 128, 95, 95, 115, 99, 114, 116, 95, 99, 111, 109, 109, 111, 110, 95, 109, 97, 105, 110, 0, 0, 0];
             let (symbol, data, name) = parse(buf).expect("parse");
             assert_eq!(symbol.raw_kind(), 0x110f);
-            assert_eq!(data, SymbolData::Procedure(ProcedureSymbol { global: false, parent: 0, end: 412, next: 0, len: 18, dbg_start_offset: 4, dbg_end_offset: 9, type_index: 4224, offset: OriginalSectionOffset { offset: 22468, section: 1 }, flags: ProcedureFlags { nofpo: false, int: false, far: false, never: false, notreached: false, cust_call: false, noinline: false, optdbginfo: true } }));
+            assert_eq!(data, SymbolData::Procedure(ProcedureSymbol { global: false, parent: 0, end: 412, next: 0, len: 18, dbg_start_offset: 4, dbg_end_offset: 9, type_index: 4224, offset: PdbInternalSectionOffset { offset: 22468, section: 1 }, flags: ProcedureFlags { nofpo: false, int: false, far: false, never: false, notreached: false, cust_call: false, noinline: false, optdbginfo: true } }));
             assert_eq!(name, "__scrt_common_main");
         }
     }

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -40,7 +40,7 @@ use pdb::AddressTranslator;
 ///     match symbol.parse() {
 ///         Ok(pdb::SymbolData::PublicSymbol(data)) if data.function => {
 ///             // we found the location of a function!
-///             let rva = data.rva(&translator);
+///             let rva = data.rva(&translator).unwrap_or(0);
 ///             println!("{:x}:{:08x} ({:08x}) is {}", data.segment, data.offset, rva, symbol.name()?);
 ///             # count += 1;
 ///         }
@@ -352,7 +352,7 @@ pub struct PublicSymbol {
 
 impl PublicSymbol {
     /// Returns the relative virtual address of this symbol.
-    pub fn rva(&self, translator: &AddressTranslator) -> u32 {
+    pub fn rva(&self, translator: &AddressTranslator) -> Option<u32> {
         translator.to_rva(self.segment, self.offset)
     }
 }
@@ -371,7 +371,7 @@ pub struct DataSymbol {
 
 impl DataSymbol {
     /// Returns the relative virtual address of this symbol.
-    pub fn rva(&self, translator: &AddressTranslator) -> u32 {
+    pub fn rva(&self, translator: &AddressTranslator) -> Option<u32> {
         translator.to_rva(self.segment, self.offset)
     }
 }
@@ -427,7 +427,7 @@ pub struct ThreadStorageSymbol {
 
 impl ThreadStorageSymbol {
     /// Returns the relative virtual address of this symbol.
-    pub fn rva(&self, translator: &AddressTranslator) -> u32 {
+    pub fn rva(&self, translator: &AddressTranslator) -> Option<u32> {
         translator.to_rva(self.segment, self.offset)
     }
 }

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -34,7 +34,7 @@ fn verify_pdb_identity() {
     let pdb_info = pdb.pdb_information().expect("pdb information");
     assert_eq!(pdb_info.guid, uuid::Uuid::from_str("3844DBB9-2017-4967-BE7A-A4A2C20430FA").unwrap());
     assert_eq!(pdb_info.age, 5);
-    assert_eq!(pdb_info.signature, 1290245416);
+    assert_eq!(pdb_info.signature, 1_290_245_416);
 }
 
 #[test]
@@ -60,19 +60,10 @@ fn test_omap() {
 
     // ensure the symbol has the correct location
     assert_eq!(pubsym.segment, 0x000c);
-    assert_eq!(pubsym.offset, 0x0004aeb0);
+    assert_eq!(pubsym.offset, 0x0004_aeb0);
 
-    // read the sections
-    let sections = pdb.sections().expect("sections");
-    assert_eq!(sections[13].name().to_string(), "PAGEVRFY");
-    assert_eq!(sections[13].virtual_address, 0x505000);
-
-    // great, good to go
-    // find the debug information
-    pdb.debug_information().expect("debug_information");
-
-    // TODO:
-    //   build an address translator
-    //   translate the segment+offset
-    //   assert_eq!(rva, 0x003768c0)
+    // translate the segment offset to an RVA
+    let translator = pdb.address_translator().expect("address translator");
+    let rva = translator.to_rva(pubsym.segment, pubsym.offset);
+    assert_eq!(rva, 0x0037_68c0);
 }

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -66,4 +66,7 @@ fn test_omap() {
     let translator = pdb.address_translator().expect("address translator");
     let rva = translator.to_rva(pubsym.segment, pubsym.offset);
     assert_eq!(rva, Some(0x0037_68c0));
+
+    let offset = translator.to_offset(0x0037_68c0);
+    assert_eq!(offset, Some((0xc, 0x0004_aeb0)));
 }

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -1,0 +1,67 @@
+extern crate pdb;
+extern crate uuid;
+
+use std::str::FromStr;
+use std::sync::{Once, ONCE_INIT};
+use pdb::FallibleIterator;
+
+// This test is intended to cover OMAP address translation:
+//   https://github.com/willglynn/pdb/issues/17
+
+static DOWNLOADED: Once = ONCE_INIT;
+fn open_file() -> std::fs::File {
+    DOWNLOADED.call_once(|| {
+        // TODO: download
+        //   https://msdl.microsoft.com/download/symbols/ntkrnlmp.pdb/3844dbb920174967be7aa4a2c20430fa2/ntkrnlmp.pdb
+        // to the path we try to open
+    });
+
+    std::fs::File::open("fixtures/symbol_server/3844dbb920174967be7aa4a2c20430fa2-ntkrnlmp.pdb")
+        .expect("opening file")
+}
+
+#[test]
+fn verify_pdb_identity() {
+    // make sure this is the right PDB
+    let mut pdb = pdb::PDB::open(open_file()).expect("opening pdb");
+
+    let pdb_info = pdb.pdb_information().expect("pdb information");
+    assert_eq!(pdb_info.guid, uuid::Uuid::from_str("3844DBB9-2017-4967-BE7A-A4A2C20430FA").unwrap());
+    assert_eq!(pdb_info.age, 5);
+    assert_eq!(pdb_info.signature, 1290245416);
+}
+
+#[test]
+fn test_omap() {
+    let mut pdb = pdb::PDB::open(open_file()).expect("opening pdb");
+
+    let global_symbols = pdb.global_symbols().expect("global_symbols");
+
+    // find the target symbol
+    let target_symbol = {
+        let target_name = pdb::RawString::from("NtWaitForSingleObject");
+        let mut iter = global_symbols.iter();
+        iter.filter(|sym| sym.name().expect("symbol name") == target_name).next()
+            .expect("iterate symbols")
+            .expect("find target symbol")
+    };
+
+    // extract the PublicSymbol data
+    let pubsym = match target_symbol.parse().expect("parse symbol") {
+        pdb::SymbolData::PublicSymbol(pubsym) => pubsym,
+        _ => panic!("expected public symbol")
+    };
+
+    // ensure the symbol has the correct location
+    assert_eq!(pubsym.segment, 0x000c);
+    assert_eq!(pubsym.offset, 0x0004aeb0);
+
+    // great, good to go
+    // find the debug information
+    pdb.debug_information().expect("debug_information");
+
+    // TODO:
+    //   build an address translator
+    //   translate the segment+offset
+    //   assert_eq!(rva, 0x003768c0)
+}

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -5,7 +5,7 @@ extern crate reqwest;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Once, ONCE_INIT};
-use pdb::{FallibleIterator, OriginalSectionOffset, Rva};
+use pdb::{FallibleIterator, PdbInternalSectionOffset, Rva};
 
 // This test is intended to cover OMAP address translation:
 //   https://github.com/willglynn/pdb/issues/17
@@ -59,13 +59,13 @@ fn test_omap() {
     };
 
     // ensure the symbol has the correct location
-    assert_eq!(pubsym.offset, OriginalSectionOffset {
+    assert_eq!(pubsym.offset, PdbInternalSectionOffset {
         section: 0xc,
         offset: 0x0004_aeb0,
     });
 
     // translate the segment offset to an RVA
     let address_map = pdb.address_map().expect("address map");
-    assert_eq!(pubsym.offset.rva(&address_map), Some(Rva(0x0037_68c0)));
-    assert_eq!(Rva(0x0037_68c0).original_offset(&address_map), Some(pubsym.offset));
+    assert_eq!(pubsym.offset.to_rva(&address_map), Some(Rva(0x0037_68c0)));
+    assert_eq!(Rva(0x0037_68c0).to_internal_offset(&address_map), Some(pubsym.offset));
 }

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -83,6 +83,11 @@ fn test_omap() {
     assert_eq!(pubsym.segment, 0x000c);
     assert_eq!(pubsym.offset, 0x0004aeb0);
 
+    // read the sections
+    let sections = pdb.sections().expect("sections");
+    assert_eq!(sections[13].name().to_string(), "PAGEVRFY");
+    assert_eq!(sections[13].virtual_address, 0x505000);
+
     // great, good to go
     // find the debug information
     pdb.debug_information().expect("debug_information");

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -65,5 +65,5 @@ fn test_omap() {
     // translate the segment offset to an RVA
     let translator = pdb.address_translator().expect("address translator");
     let rva = translator.to_rva(pubsym.segment, pubsym.offset);
-    assert_eq!(rva, 0x0037_68c0);
+    assert_eq!(rva, Some(0x0037_68c0));
 }


### PR DESCRIPTION
This picks up on the work done and discussed at https://github.com/willglynn/pdb/issues/17 and adds the missing `AddressTranslator`.

Additionally, this PR slightly restructures when and how the optional debug header (_"extra streams"_) are read. This is now performed lazily only when needed to speed up parsing of the initial PDB struct. While parsing the optional header is not a ton of work, it's still avoidable if one is only interested in some of the other streams.

There are also a bunch of new public methods on the PDB, namely: `omap_from_src`, `omap_to_src`, `original_sections`. The use of `AddressTranslator` is still preferred, but in case someone wants to use those directly, they get a handle to this. I suppose it might be cleaner to put all these methods in a different place, but since they need to read and modify the inner `msf`, this was most straight forward for now.

I'm still not a big fan that reading `sections` and `original_sections` is not done in a zero-copy way. We should probably pick a solution before merging this in: 
 - Read them only once and store them in the PDB, just like the extra streams. Then, just return a slice.
 - Change `ImageSectionHeader` into a view on the original data (slice), similar to `RawString` and add methods for all currently public fields.