### PR TITLE
Add an explicit type for stream indices

### DIFF
--- a/examples/stream_names.rs
+++ b/examples/stream_names.rs
@@ -7,7 +7,7 @@ fn dump_stream_names(filename: &OsStr) -> pdb::Result<()> {
     let names = info.stream_names()?;
     println!("index, name");
     for name in &names {
-        let stream = pdb.raw_stream(name.stream_id)?;
+        let stream = pdb.raw_stream(name.stream_id)?.expect("named stream");
         println!("{:5}, {} {} bytes", name.stream_id, name.name, stream.len());
     }
     Ok(())

--- a/src/common.rs
+++ b/src/common.rs
@@ -48,6 +48,9 @@ pub enum Error {
     /// This data might be understandable, but the code needed to understand it hasn't been written.
     UnimplementedFeature(&'static str),
 
+    /// The global shared symbol table is missing.
+    GlobalSymbolsNotFound,
+
     /// A symbol record's length value was impossibly small.
     SymbolTooShort,
 
@@ -105,6 +108,7 @@ impl std::error::Error for Error {
             Error::IoError(ref e) => e.description(),
             Error::UnexpectedEof => "Unexpectedly reached end of input",
             Error::UnimplementedFeature(_) => "Unimplemented PDB feature",
+            Error::GlobalSymbolsNotFound => "The global symbol stream is missing",
             Error::SymbolTooShort => "A symbol record's length value was impossibly small",
             Error::UnimplementedSymbolKind(_) => {
                 "Support for symbols of this kind is not implemented"
@@ -172,10 +176,6 @@ impl fmt::Display for Error {
                 f,
                 "Variable-length numeric parsing encountered an unexpected prefix (0x{:04x}",
                 prefix
-            ),
-            Error::AddressMapNotFound => write!(
-                f,
-                "Required mapping for virtual addresses (OMAP) was not found"
             ),
             Error::UnimplementedDebugSubsection(kind) => write!(
                 f,
@@ -409,6 +409,73 @@ impl fmt::Debug for PdbInternalSectionOffset {
             .field("section", &format!("{:#x}", self.section))
             .field("offset", &format!("{:#010x}", self.offset))
             .finish()
+    }
+}
+
+/// Index of a PDB stream.
+///
+/// This index can either refer to a stream, or indicate the absence of a stream. Check [`is_none`]
+/// to see whether a stream should exist.
+///
+/// Use [`StreamIndex::get`] to load data for this stream.
+///
+/// [`is_none`]: struct.StreamIndex.html#method.is_none
+/// [`StreamIndex::get`]: struct.StreamIndex.html#method.get
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct StreamIndex(pub u16);
+
+impl StreamIndex {
+    /// Creates a stream index that points to no stream.
+    pub fn none() -> Self {
+        StreamIndex(0xffff)
+    }
+
+    /// Determines whether this index indicates the absence of a stream.
+    ///
+    /// Loading a missing stream from the PDB will result in `None`. Otherwise, the stream is
+    /// expected to be present in the MSF and will result in an error if loading.
+    #[inline]
+    pub fn is_none(self) -> bool {
+        self.msf_number().is_none()
+    }
+
+    /// Returns the MSF stream number, if this stream is not a NULL stream.
+    #[inline]
+    pub(crate) fn msf_number(self) -> Option<u32> {
+        match self.0 {
+            0xffff => None,
+            index => Some(u32::from(index)),
+        }
+    }
+}
+
+impl Default for StreamIndex {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+impl fmt::Display for StreamIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.msf_number() {
+            Some(number) => write!(f, "{}", number),
+            None => write!(f, "None"),
+        }
+    }
+}
+
+impl fmt::Debug for StreamIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "StreamIndex({})", self)
+    }
+}
+
+impl<'a> TryFromCtx<'a, Endian> for StreamIndex {
+    type Error = scroll::Error;
+    type Size = usize;
+
+    fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+        u16::try_from_ctx(this, le).map(|(i, s)| (StreamIndex(i), s))
     }
 }
 

--- a/src/pdbi.rs
+++ b/src/pdbi.rs
@@ -129,7 +129,7 @@ impl<'s> PDBInformation<'s> {
             let names_buf = names_reader.take(self.names_size)?;
             for _ in 0..count {
                 let name_offset = buf.parse_u32()? as usize;
-                let stream_id = buf.parse_u32()?;
+                let stream_id = StreamIndex(buf.parse_u32()? as u16);
                 let name = ParseBuffer::from(&names_buf[name_offset..]).parse_cstring()?;
                 names.push(StreamName { name, stream_id });
             }
@@ -145,7 +145,7 @@ pub struct StreamName<'n> {
     /// The stream's name.
     pub name: RawString<'n>,
     /// The index of this stream.
-    pub stream_id: u32,
+    pub stream_id: StreamIndex,
 }
 
 /// A list of named streams contained within the PDB file.


### PR DESCRIPTION
While the MSF stores the stream count as `u32`, it seems to be a general pattern in PDBs to store `u16` stream indices and indicate the absence of a stream with `0xffff`. To abstract this behavior, this PR introduces a transparent `StreamIndex` type.

All code is refactored to use this new type now. As a nice side effect, the access to DBI extra streams is now much smoother. Also, this forces us to check for the absence of streams more consistently when using stream indices internally (e.g. as it was missed for module info streams initially).

The only exception to this seems to be the named stream table, which contains `u32` stream indices. I've decided to make a lossy conversion to a `StreamIndex`, since this is in the public interface. In general, the `StreamNames` type might need a refactor, but that's for a different PR.