### PR TITLE
Fix an invalid check when aligning buffers

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1109,5 +1109,30 @@ mod tests {
                 _ => panic!("expected EOF"),
             }
         }
+
+        #[test]
+        fn test_parse_buffer_align() {
+            let mut buf = ParseBuffer::from("1234".as_bytes());
+            buf.take(1).unwrap();
+            assert!(buf.align(4).is_ok());
+            assert_eq!(buf.pos(), 4);
+            assert_eq!(buf.len(), 0);
+
+            let mut buf = ParseBuffer::from("1234".as_bytes());
+            buf.take(3).unwrap();
+            assert!(buf.align(4).is_ok());
+            assert_eq!(buf.pos(), 4);
+            assert_eq!(buf.len(), 0);
+
+            let mut buf = ParseBuffer::from("12345".as_bytes());
+            buf.take(3).unwrap();
+            assert!(buf.align(4).is_ok());
+            assert_eq!(buf.pos(), 4);
+            assert_eq!(buf.len(), 1);
+
+            let mut buf = ParseBuffer::from("123".as_bytes());
+            buf.take(3).unwrap();
+            assert!(buf.align(4).is_err());
+        }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -662,7 +662,7 @@ impl<'b> ParseBuffer<'b> {
     pub fn align(&mut self, alignment: usize) -> Result<()> {
         let diff = self.1 % alignment;
         if diff > 0 {
-            if self.len() < diff {
+            if self.len() < (alignment - diff) {
                 return Err(Error::UnexpectedEof);
             }
             self.1 += alignment - diff;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1112,25 +1112,25 @@ mod tests {
 
         #[test]
         fn test_parse_buffer_align() {
-            let mut buf = ParseBuffer::from("1234".as_bytes());
+            let mut buf = ParseBuffer::from(&b"1234"[..]);
             buf.take(1).unwrap();
             assert!(buf.align(4).is_ok());
             assert_eq!(buf.pos(), 4);
             assert_eq!(buf.len(), 0);
 
-            let mut buf = ParseBuffer::from("1234".as_bytes());
+            let mut buf = ParseBuffer::from(&b"1234"[..]);
             buf.take(3).unwrap();
             assert!(buf.align(4).is_ok());
             assert_eq!(buf.pos(), 4);
             assert_eq!(buf.len(), 0);
 
-            let mut buf = ParseBuffer::from("12345".as_bytes());
+            let mut buf = ParseBuffer::from(&b"12345"[..]);
             buf.take(3).unwrap();
             assert!(buf.align(4).is_ok());
             assert_eq!(buf.pos(), 4);
             assert_eq!(buf.len(), 1);
 
-            let mut buf = ParseBuffer::from("123".as_bytes());
+            let mut buf = ParseBuffer::from(&b"123"[..]);
             buf.take(3).unwrap();
             assert!(buf.align(4).is_err());
         }


### PR DESCRIPTION
The alignment check in `ParseBuffer` was invalid and might have led to a premature `UnexpectedEof` error.