### PR TITLE
Implement support for IPI types

### DIFF
--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -614,7 +614,7 @@ fn write_class(filename: &str, class_name: &str) -> pdb::Result<()> {
             if class.name.as_bytes() == class_name.as_bytes()
                 && !class.properties.forward_reference()
             {
-                data.add(&type_finder, typ.type_index(), &mut needed_types)?;
+                data.add(&type_finder, typ.index(), &mut needed_types)?;
                 break;
             }
         }

--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -600,7 +600,7 @@ fn write_class(filename: &str, class_name: &str) -> pdb::Result<()> {
     let mut pdb = pdb::PDB::open(file)?;
 
     let type_information = pdb.type_information()?;
-    let mut type_finder = type_information.type_finder();
+    let mut type_finder = type_information.finder();
 
     let mut needed_types = TypeSet::new();
     let mut data = Data::new();

--- a/src/common.rs
+++ b/src/common.rs
@@ -63,11 +63,11 @@ pub enum Error {
     /// A type record's length value was impossibly small.
     TypeTooShort,
 
-    /// Type not found.
+    /// Type or Id not found.
     TypeNotFound(u32),
 
-    /// Type not indexed -- the requested type (`.0`) is larger than the maximum `TypeIndex` covered
-    /// by the `TypeFinder` (`.1`).
+    /// Type or Id not indexed -- the requested type (`.0`) is larger than the maximum index covered
+    /// by the `ItemFinder` (`.1`).
     TypeNotIndexed(u32, u32),
 
     /// Support for types of this kind is not implemented.
@@ -579,9 +579,10 @@ impl fmt::Debug for StreamIndex {
 impl_opt!(StreamIndex, 0xffff);
 impl_pread!(StreamIndex);
 
-/// Index of a [`Type`] in `PDB.type_information()`.
+/// Index of a [`Type`] in the [`TypeInformation`] stream.
 ///
-/// [`Type`]: struct.Type.html
+/// [`Type`]: type.Type.html
+/// [`TypeInformation`]: type.TypeInformation.html
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeIndex(pub u32);
 
@@ -589,7 +590,10 @@ impl_convert!(TypeIndex, u32);
 impl_hex_fmt!(TypeIndex);
 impl_pread!(TypeIndex);
 
-/// Index of an [`Id`] in `PDB. id_information()`.
+/// Index of an [`Id`] in [`IdInformation`] stream.
+///
+/// [`Id`]: type.Id.html
+/// [`IdInformation`]: type.IdInformation.html
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IdIndex(pub u32);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,11 +64,11 @@ pub enum Error {
     TypeTooShort,
 
     /// Type not found.
-    TypeNotFound(TypeIndex),
+    TypeNotFound(u32),
 
     /// Type not indexed -- the requested type (`.0`) is larger than the maximum `TypeIndex` covered
     /// by the `TypeFinder` (`.1`).
-    TypeNotIndexed(TypeIndex, TypeIndex),
+    TypeNotIndexed(u32, u32),
 
     /// Support for types of this kind is not implemented.
     UnimplementedTypeKind(u16),

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -86,7 +86,7 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     ///
     /// # Errors
     ///
-    /// * `Error::StreamNotFound` if the PDB somehow does not contain the type information stream
+    /// * `Error::StreamNotFound` if the PDB does not contain the type information stream
     /// * `Error::IoError` if returned by the `Source`
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
     /// * `Error::InvalidTypeInformationHeader` if the type information stream header was not
@@ -96,16 +96,16 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
         TypeInformation::parse(stream)
     }
 
-    /// Retrieve the `TypeInformation` for this PDB.
+    /// Retrieve the `IdInformation` for this PDB.
     ///
     /// The `IdInformation` object owns a `SourceView` for the type information ("IPI") stream.
     ///
     /// # Errors
     ///
-    /// * `Error::StreamNotFound` if the PDB somehow does not contain the type information stream
+    /// * `Error::StreamNotFound` if the PDB does not contain the id information stream
     /// * `Error::IoError` if returned by the `Source`
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
-    /// * `Error::InvalidTypeInformationHeader` if the type information stream header was not
+    /// * `Error::InvalidTypeInformationHeader` if the id information stream header was not
     ///   understood
     pub fn id_information(&mut self) -> Result<IdInformation<'s>> {
         let stream = self.msf.get(IPI_STREAM, None)?;

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -16,7 +16,7 @@ use crate::pe::ImageSectionHeader;
 use crate::source::Source;
 use crate::strings::StringTable;
 use crate::symbol::SymbolTable;
-use crate::tpi::TypeInformation;
+use crate::tpi::{IdInformation, TypeInformation};
 
 /// Some streams have a fixed stream index.
 /// http://llvm.org/docs/PDB/index.html
@@ -24,7 +24,6 @@ use crate::tpi::TypeInformation;
 const PDB_STREAM: u32 = 1;
 const TPI_STREAM: u32 = 2;
 const DBI_STREAM: u32 = 3;
-#[allow(unused)]
 const IPI_STREAM: u32 = 4;
 
 /// `PDB` provides access to the data within a PDB file.
@@ -95,6 +94,22 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     pub fn type_information(&mut self) -> Result<TypeInformation<'s>> {
         let stream = self.msf.get(TPI_STREAM, None)?;
         TypeInformation::parse(stream)
+    }
+
+    /// Retrieve the `TypeInformation` for this PDB.
+    ///
+    /// The `IdInformation` object owns a `SourceView` for the type information ("IPI") stream.
+    ///
+    /// # Errors
+    ///
+    /// * `Error::StreamNotFound` if the PDB somehow does not contain the type information stream
+    /// * `Error::IoError` if returned by the `Source`
+    /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
+    /// * `Error::InvalidTypeInformationHeader` if the type information stream header was not
+    ///   understood
+    pub fn id_information(&mut self) -> Result<IdInformation<'s>> {
+        let stream = self.msf.get(IPI_STREAM, None)?;
+        IdInformation::parse(stream)
     }
 
     /// Retrieve the `DebugInformation` for this PDB.

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -645,25 +645,6 @@ impl FunctionAttributes {
     }
 }
 
-/*
-typedef enum CV_ptrtype_e {
-    CV_PTR_NEAR         = 0x00, // 16 bit pointer
-    CV_PTR_FAR          = 0x01, // 16:16 far pointer
-    CV_PTR_HUGE         = 0x02, // 16:16 huge pointer
-    CV_PTR_BASE_SEG     = 0x03, // based on segment
-    CV_PTR_BASE_VAL     = 0x04, // based on value of base
-    CV_PTR_BASE_SEGVAL  = 0x05, // based on segment value of base
-    CV_PTR_BASE_ADDR    = 0x06, // based on address of base
-    CV_PTR_BASE_SEGADDR = 0x07, // based on segment address of base
-    CV_PTR_BASE_TYPE    = 0x08, // based on type
-    CV_PTR_BASE_SELF    = 0x09, // based on self
-    CV_PTR_NEAR32       = 0x0a, // 32 bit pointer
-    CV_PTR_FAR32        = 0x0b, // 16:32 pointer
-    CV_PTR_64           = 0x0c, // 64 bit pointer
-    CV_PTR_UNUSEDPTR    = 0x0d  // first unused pointer type
-} CV_ptrtype_e;
-*/
-
 /// The kind of a `PointerType`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PointerKind {
@@ -694,18 +675,6 @@ pub enum PointerKind {
     /// 64 bit pointer.
     Ptr64,
 }
-
-/*
-typedef enum CV_ptrmode_e {
-    CV_PTR_MODE_PTR     = 0x00, // "normal" pointer
-    CV_PTR_MODE_REF     = 0x01, // "old" reference
-    CV_PTR_MODE_LVREF   = 0x01, // l-value reference
-    CV_PTR_MODE_PMEM    = 0x02, // pointer to data member
-    CV_PTR_MODE_PMFUNC  = 0x03, // pointer to member function
-    CV_PTR_MODE_RVREF   = 0x04, // r-value reference
-    CV_PTR_MODE_RESERVED= 0x05  // first unused pointer mode
-} CV_ptrmode_e;
-*/
 
 /// The mode of a `PointerType`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/tpi/header.rs
+++ b/src/tpi/header.rs
@@ -20,8 +20,8 @@ pub struct Slice {
 pub struct Header {
     pub version: u32,
     pub header_size: u32,
-    pub minimum_type_index: TypeIndex,
-    pub maximum_type_index: TypeIndex,
+    pub minimum_index: u32,
+    pub maximum_index: u32,
     pub gprec_size: u32,
     pub tpi_hash_stream: u16,
     pub tpi_hash_pad_stream: u16,
@@ -39,8 +39,8 @@ impl Header {
         let header = Header {
             version: buf.parse()?,
             header_size: buf.parse()?,
-            minimum_type_index: buf.parse()?,
-            maximum_type_index: buf.parse()?,
+            minimum_index: buf.parse()?,
+            maximum_index: buf.parse()?,
             gprec_size: buf.parse()?,
             tpi_hash_stream: buf.parse()?,
             tpi_hash_pad_stream: buf.parse()?,
@@ -77,12 +77,12 @@ impl Header {
         buf.take((header.header_size - bytes_read) as usize)?;
 
         // do some final validations
-        if header.minimum_type_index < TypeIndex(4096) {
+        if header.minimum_index < 4096 {
             return Err(Error::InvalidTypeInformationHeader(
                 "minimum type index is < 4096",
             ));
         }
-        if header.maximum_type_index < header.minimum_type_index {
+        if header.maximum_index < header.minimum_index {
             return Err(Error::InvalidTypeInformationHeader(
                 "maximum type index is < minimum type index",
             ));

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -1,0 +1,158 @@
+use scroll::ctx::TryFromCtx;
+
+use crate::common::*;
+use crate::tpi::constants::*;
+
+#[inline]
+fn parse_optional_type_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<TypeIndex>> {
+    let index = buf.parse()?;
+    if index == TypeIndex(0) || index == TypeIndex(0xffff) {
+        Ok(None)
+    } else {
+        Ok(Some(index))
+    }
+}
+
+// TODO(ja): MOve these
+#[inline]
+fn parse_optional_id_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<IdIndex>> {
+    Ok(match buf.parse()? {
+        IdIndex(0) => None,
+        index => Some(index),
+    })
+}
+
+#[inline]
+fn parse_string<'t>(leaf: u16, buf: &mut ParseBuffer<'t>) -> Result<RawString<'t>> {
+    if leaf > LF_ST_MAX {
+        buf.parse_cstring()
+    } else {
+        buf.parse_u8_pascal_string()
+    }
+}
+
+/// Encapsulates parsed data about an `Id`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdData<'t> {
+    FunctionId(FunctionIdType<'t>),
+    MemberFunctionId(MemberFunctionIdType<'t>),
+    BuildInfoId(BuildInfoIdType),
+    SubstringList(SubstringListType),
+    StringId(StringIdType<'t>),
+    UserDefinedTypeSource(UserDefinedTypeSourceType),
+}
+
+impl<'t> IdData<'t> {}
+
+impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
+    type Error = Error;
+    type Size = usize;
+
+    fn try_from_ctx(this: &'t [u8], _ctx: scroll::Endian) -> Result<(Self, Self::Size)> {
+        let mut buf = ParseBuffer::from(this);
+        let leaf = buf.parse_u16()?;
+
+        let data = match leaf {
+            LF_FUNC_ID => IdData::FunctionId(FunctionIdType {
+                scope: parse_optional_id_index(&mut buf)?,
+                function_type: buf.parse()?,
+                name: parse_string(leaf, &mut buf)?,
+            }),
+            LF_MFUNC_ID => IdData::MemberFunctionId(MemberFunctionIdType {
+                parent: parse_optional_type_index(&mut buf)?,
+                function_type: buf.parse()?,
+                name: parse_string(leaf, &mut buf)?,
+            }),
+            LF_BUILDINFO => IdData::BuildInfoId({
+                let count = buf.parse::<u16>()?;
+                let mut arguments = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    arguments.push(buf.parse()?);
+                }
+                BuildInfoIdType { arguments }
+            }),
+            LF_SUBSTR_LIST => IdData::SubstringList({
+                let count = buf.parse::<u32>()?;
+                let mut substrings = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    substrings.push(buf.parse()?);
+                }
+                SubstringListType { substrings }
+            }),
+            LF_STRING_ID => IdData::StringId(StringIdType {
+                substrings: buf.parse()?,
+                name: parse_string(leaf, &mut buf)?,
+            }),
+            LF_UDT_SRC_LINE | LF_UDT_MOD_SRC_LINE => {
+                let mut udt = UserDefinedTypeSourceType {
+                    udt: buf.parse()?,
+                    source_file: buf.parse()?,
+                    line: buf.parse()?,
+                    module: None,
+                };
+
+                if leaf == LF_UDT_MOD_SRC_LINE {
+                    udt.module = Some(buf.parse()?);
+                }
+
+                IdData::UserDefinedTypeSource(udt)
+            }
+            _ => return Err(Error::UnimplementedTypeKind(leaf)),
+        };
+
+        Ok((data, buf.pos()))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FunctionIdType<'t> {
+    /// Parent scope of this id.
+    scope: Option<IdIndex>,
+    /// Index of the function type declaration.
+    function_type: TypeIndex,
+    name: RawString<'t>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MemberFunctionIdType<'t> {
+    /// Index of the parent type.
+    parent: Option<TypeIndex>,
+    /// Index of the member function type declaration.
+    function_type: TypeIndex,
+    /// Name of the member function.
+    name: RawString<'t>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuildInfoIdType {
+    /// Indexes of build arguments.
+    arguments: Vec<IdIndex>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubstringListType {
+    /// The list of substrings.
+    pub substrings: Vec<TypeIndex>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StringIdType<'t> {
+    /// Index of the list of substrings.
+    substrings: IdIndex,
+    /// The string.
+    name: RawString<'t>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UserDefinedTypeSourceType {
+    /// Index of the UDT's type definition.
+    udt: TypeIndex,
+    /// Index of the source file name.
+    source_file: IdIndex,
+    /// Line number in the source file.
+    line: u32,
+    /// Module that contributes this UDT definition.
+    ///
+    /// If None, the UDT is declared in the same module.
+    module: Option<u16>,
+}

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -3,16 +3,6 @@ use scroll::ctx::TryFromCtx;
 use crate::common::*;
 use crate::tpi::constants::*;
 
-#[inline]
-fn parse_optional_type_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<TypeIndex>> {
-    let index = buf.parse()?;
-    if index == TypeIndex(0) || index == TypeIndex(0xffff) {
-        Ok(None)
-    } else {
-        Ok(Some(index))
-    }
-}
-
 // TODO(ja): MOve these
 #[inline]
 fn parse_optional_id_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<IdIndex>> {
@@ -34,12 +24,12 @@ fn parse_string<'t>(leaf: u16, buf: &mut ParseBuffer<'t>) -> Result<RawString<'t
 /// Encapsulates parsed data about an `Id`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdData<'t> {
-    FunctionId(FunctionIdType<'t>),
-    MemberFunctionId(MemberFunctionIdType<'t>),
-    BuildInfoId(BuildInfoIdType),
-    SubstringList(SubstringListType),
-    StringId(StringIdType<'t>),
-    UserDefinedTypeSource(UserDefinedTypeSourceType),
+    Function(FunctionId<'t>),
+    MemberFunction(MemberFunctionId<'t>),
+    BuildInfo(BuildInfoId),
+    StringList(StringListId),
+    String(StringId<'t>),
+    UserDefinedTypeSource(UserDefinedTypeSourceId),
 }
 
 impl<'t> IdData<'t> {}
@@ -53,38 +43,38 @@ impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
         let leaf = buf.parse_u16()?;
 
         let data = match leaf {
-            LF_FUNC_ID => IdData::FunctionId(FunctionIdType {
+            LF_FUNC_ID => IdData::Function(FunctionId {
                 scope: parse_optional_id_index(&mut buf)?,
                 function_type: buf.parse()?,
                 name: parse_string(leaf, &mut buf)?,
             }),
-            LF_MFUNC_ID => IdData::MemberFunctionId(MemberFunctionIdType {
-                parent: parse_optional_type_index(&mut buf)?,
+            LF_MFUNC_ID => IdData::MemberFunction(MemberFunctionId {
+                parent: buf.parse()?,
                 function_type: buf.parse()?,
                 name: parse_string(leaf, &mut buf)?,
             }),
-            LF_BUILDINFO => IdData::BuildInfoId({
+            LF_BUILDINFO => IdData::BuildInfo({
                 let count = buf.parse::<u16>()?;
                 let mut arguments = Vec::with_capacity(count as usize);
                 for _ in 0..count {
                     arguments.push(buf.parse()?);
                 }
-                BuildInfoIdType { arguments }
+                BuildInfoId { arguments }
             }),
-            LF_SUBSTR_LIST => IdData::SubstringList({
+            LF_SUBSTR_LIST => IdData::StringList({
                 let count = buf.parse::<u32>()?;
                 let mut substrings = Vec::with_capacity(count as usize);
                 for _ in 0..count {
                     substrings.push(buf.parse()?);
                 }
-                SubstringListType { substrings }
+                StringListId { substrings }
             }),
-            LF_STRING_ID => IdData::StringId(StringIdType {
-                substrings: buf.parse()?,
+            LF_STRING_ID => IdData::String(StringId {
+                substrings: parse_optional_id_index(&mut buf)?,
                 name: parse_string(leaf, &mut buf)?,
             }),
             LF_UDT_SRC_LINE | LF_UDT_MOD_SRC_LINE => {
-                let mut udt = UserDefinedTypeSourceType {
+                let mut udt = UserDefinedTypeSourceId {
                     udt: buf.parse()?,
                     source_file: buf.parse()?,
                     line: buf.parse()?,
@@ -105,54 +95,55 @@ impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FunctionIdType<'t> {
+pub struct FunctionId<'t> {
     /// Parent scope of this id.
-    scope: Option<IdIndex>,
+    pub scope: Option<IdIndex>,
     /// Index of the function type declaration.
-    function_type: TypeIndex,
-    name: RawString<'t>,
+    pub function_type: TypeIndex,
+    /// Name of the function.
+    pub name: RawString<'t>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MemberFunctionIdType<'t> {
+pub struct MemberFunctionId<'t> {
     /// Index of the parent type.
-    parent: Option<TypeIndex>,
+    pub parent: TypeIndex,
     /// Index of the member function type declaration.
-    function_type: TypeIndex,
+    pub function_type: TypeIndex,
     /// Name of the member function.
-    name: RawString<'t>,
+    pub name: RawString<'t>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BuildInfoIdType {
+pub struct BuildInfoId {
     /// Indexes of build arguments.
-    arguments: Vec<IdIndex>,
+    pub arguments: Vec<IdIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SubstringListType {
+pub struct StringListId {
     /// The list of substrings.
     pub substrings: Vec<TypeIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StringIdType<'t> {
+pub struct StringId<'t> {
     /// Index of the list of substrings.
-    substrings: IdIndex,
+    pub substrings: Option<IdIndex>,
     /// The string.
-    name: RawString<'t>,
+    pub name: RawString<'t>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UserDefinedTypeSourceType {
+pub struct UserDefinedTypeSourceId {
     /// Index of the UDT's type definition.
-    udt: TypeIndex,
+    pub udt: TypeIndex,
     /// Index of the source file name.
-    source_file: IdIndex,
+    pub source_file: IdIndex,
     /// Line number in the source file.
-    line: u32,
+    pub line: u32,
     /// Module that contributes this UDT definition.
     ///
     /// If None, the UDT is declared in the same module.
-    module: Option<u16>,
+    pub module: Option<u16>,
 }

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -3,7 +3,6 @@ use scroll::ctx::TryFromCtx;
 use crate::common::*;
 use crate::tpi::constants::*;
 
-// TODO(ja): MOve these
 #[inline]
 fn parse_optional_id_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<IdIndex>> {
     Ok(match buf.parse()? {

--- a/src/tpi/primitive.rs
+++ b/src/tpi/primitive.rs
@@ -176,7 +176,7 @@ pub fn type_data_for_primitive(index: TypeIndex) -> Result<TypeData<'static>> {
         0x500 => Indirection::Pointer1632,
         0x600 => Indirection::Pointer64,
         _ => {
-            return Err(Error::TypeNotFound(index));
+            return Err(Error::TypeNotFound(index.0));
         }
     };
 
@@ -235,7 +235,7 @@ pub fn type_data_for_primitive(index: TypeIndex) -> Result<TypeData<'static>> {
         0x33 => PrimitiveKind::Bool64,
 
         _ => {
-            return Err(Error::TypeNotFound(index));
+            return Err(Error::TypeNotFound(index.0));
         }
     };
 

--- a/tests/type_information.rs
+++ b/tests/type_information.rs
@@ -28,8 +28,8 @@ fn iteration() {
         let mut last_index = pdb::TypeIndex(4095);
         let mut iter = type_information.iter();
         while let Some(typ) = iter.next().expect("next type") {
-            assert_eq!(typ.type_index().0, last_index.0 + 1);
-            last_index = typ.type_index();
+            assert_eq!(typ.index().0, last_index.0 + 1);
+            last_index = typ.index();
             count += 1;
         }
 
@@ -48,21 +48,18 @@ fn type_finder() {
         // iterate over all the types
         let mut iter = type_information.iter();
         while let Some(typ) = iter.next().expect("next type") {
-            assert_eq!(
-                type_finder.max_indexed_type().0 >> 3,
-                typ.type_index().0 >> 3
-            );
+            assert_eq!(type_finder.max_indexed_type().0 >> 3, typ.index().0 >> 3);
 
             // update the type finder
             type_finder.update(&iter);
 
             // record this type in our map
-            map.insert(typ.type_index(), typ);
+            map.insert(typ.index(), typ);
         }
 
         // iterate over the map -- which is randomized -- making sure the type finder finds identical types
-        for (type_index, typ) in map.iter() {
-            let found = type_finder.find(*type_index).expect("find");
+        for (index, typ) in map.iter() {
+            let found = type_finder.find(*index).expect("find");
             assert_eq!(*typ, found);
         }
     })
@@ -87,7 +84,7 @@ fn find_classes() {
                     ..
                 })) => {
                     // this Type describes a class-like type with fields
-                    println!("class {} (type {}):", name, typ.type_index());
+                    println!("class {} (type {}):", name, typ.index());
 
                     // fields is presently a TypeIndex
                     // find and parse the list of fields
@@ -146,7 +143,7 @@ fn find_classes() {
                     // other parse error
                     println!(
                         "other parse error on type {} (raw type {:04x}): {}",
-                        typ.type_index(),
+                        typ.index(),
                         typ.raw_kind(),
                         e
                     );
@@ -163,14 +160,14 @@ fn find_classes() {
 #[bench]
 fn bench_type_finder(b: &mut test::Bencher) {
     setup(|type_information| {
-        let mut type_finder = type_information.new_type_finder();
+        let mut type_finder = type_information.type_finder();
 
         assert_eq!(type_finder.max_indexed_type() >> 3, 4096 >> 3);
 
         // iterate over all the types
         let mut iter = type_information.iter();
         while let Some(typ) = iter.next().expect("next type") {
-            assert_eq!(type_finder.max_indexed_type() >> 3, typ.type_index() >> 3);
+            assert_eq!(type_finder.max_indexed_type() >> 3, typ.index() >> 3);
             type_finder.update(&iter);
         }
 

--- a/tests/type_information.rs
+++ b/tests/type_information.rs
@@ -40,15 +40,15 @@ fn iteration() {
 #[test]
 fn type_finder() {
     setup(|type_information| {
-        let mut type_finder = type_information.type_finder();
+        let mut type_finder = type_information.finder();
         let mut map: HashMap<pdb::TypeIndex, pdb::Type<'_>> = HashMap::new();
 
-        assert_eq!(type_finder.max_indexed_type().0 >> 3, 4096 >> 3);
+        assert_eq!(type_finder.max_index().0 >> 3, 4096 >> 3);
 
         // iterate over all the types
         let mut iter = type_information.iter();
         while let Some(typ) = iter.next().expect("next type") {
-            assert_eq!(type_finder.max_indexed_type().0 >> 3, typ.index().0 >> 3);
+            assert_eq!(type_finder.max_index().0 >> 3, typ.index().0 >> 3);
 
             // update the type finder
             type_finder.update(&iter);
@@ -68,7 +68,7 @@ fn type_finder() {
 #[test]
 fn find_classes() {
     setup(|type_information| {
-        let mut type_finder = type_information.type_finder();
+        let mut type_finder = type_information.finder();
 
         // iterate over all the types
         let mut iter = type_information.iter();
@@ -160,14 +160,14 @@ fn find_classes() {
 #[bench]
 fn bench_type_finder(b: &mut test::Bencher) {
     setup(|type_information| {
-        let mut type_finder = type_information.type_finder();
+        let mut type_finder = type_information.finder();
 
-        assert_eq!(type_finder.max_indexed_type() >> 3, 4096 >> 3);
+        assert_eq!(type_finder.max_index() >> 3, 4096 >> 3);
 
         // iterate over all the types
         let mut iter = type_information.iter();
         while let Some(typ) = iter.next().expect("next type") {
-            assert_eq!(type_finder.max_indexed_type() >> 3, typ.index() >> 3);
+            assert_eq!(type_finder.max_index() >> 3, typ.index() >> 3);
             type_finder.update(&iter);
         }
 


### PR DESCRIPTION
This PR exposes the ID stream (IPI). 

The TPI and IPI streams share the same structure, but they contain different records. Most importantly, the type of index used indicates whether a type lives in the IPI or the TPI. In `microsoft-pdb` this is either `CV_typ_t` for types, or `CV_ItemId` for ids. Of course, both are `u32`.

To create a clear interface that avoids confusion, identifiers are clearly separated into `TypeIndex(u32)` and `IdIndex(u32)`. Since now the id stream needs the same root struct, iterator and finder, this is abstracted into `ItemInformation<I>`, `ItemIter<I>` and `ItemFinder<I>`, where `I` is the index being used. On top of that, there are type definitions to simplify the handling of such types: `type Type<'t> = Item<'t, TypeIndex>`, etc.

Apart from some renaming for consistency, usage stays mostly the same.

Unrelated, this PR contains two more fixes. They can be moved into separate PRs if desired:
 - Flags and modes of pointer types have been implemented (and fixed)
 - Some types have a "unique name", i.e. the partially mangled type name. It is exposed now.
