### PR TITLE
Fix parsing of primitive type indirections

### DIFF
--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -34,12 +34,8 @@ pub fn type_name<'p>(
                 _ => format!("unhandled_primitive.kind /* {:?} */", data.kind),
             };
 
-            match data.indirection {
-                pdb::Indirection::None => {}
-                _ => {
-                    name.push(' ');
-                    name.push('*');
-                }
+            if data.indirection.is_some() {
+                name.push_str(" *");
             }
 
             name


### PR DESCRIPTION
This changes the variants of the `Indirection` enum to align with `PointerKind` and also the names used in Microsoft PDB.

Additionally, this fixes a bug when parsing `Huge16` (0x3), which was incorrectly parsed into `Far16` before.