### PR TITLE
Handle empty TPI and IPI streams

### DIFF
--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -107,9 +107,13 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
     /// * `Error::InvalidTypeInformationHeader` if the id information stream header was not
     ///   understood
-    pub fn id_information(&mut self) -> Result<IdInformation<'s>> {
+    pub fn id_information(&mut self) -> Result<Option<IdInformation<'s>>> {
         let stream = self.msf.get(IPI_STREAM, None)?;
-        IdInformation::parse(stream)
+        if stream.is_empty() {
+            Ok(None)
+        } else {
+            IdInformation::parse(stream).map(Some)
+        }
     }
 
     /// Retrieve the `DebugInformation` for this PDB.

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -107,13 +107,9 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
     /// * `Error::InvalidTypeInformationHeader` if the id information stream header was not
     ///   understood
-    pub fn id_information(&mut self) -> Result<Option<IdInformation<'s>>> {
+    pub fn id_information(&mut self) -> Result<IdInformation<'s>> {
         let stream = self.msf.get(IPI_STREAM, None)?;
-        if stream.is_empty() {
-            Ok(None)
-        } else {
-            IdInformation::parse(stream).map(Some)
-        }
+        IdInformation::parse(stream)
     }
 
     /// Retrieve the `DebugInformation` for this PDB.

--- a/src/tpi/header.rs
+++ b/src/tpi/header.rs
@@ -33,8 +33,34 @@ pub struct Header {
 }
 
 impl Header {
+    pub(crate) fn empty() -> Self {
+        let empty_slice = Slice { offset: 0, size: 0 };
+
+        Header {
+            version: 0,
+            header_size: 0,
+            minimum_index: 0,
+            maximum_index: 0,
+            gprec_size: 0,
+            tpi_hash_stream: 0,
+            tpi_hash_pad_stream: 0,
+            hash_key_size: 0,
+            hash_bucket_size: 0,
+            hash_values: empty_slice,
+            ti_off: empty_slice,
+            hash_adj: empty_slice,
+        }
+    }
+
     pub(crate) fn parse(buf: &mut ParseBuffer<'_>) -> Result<Self> {
-        assert!(buf.pos() == 0);
+        debug_assert!(buf.pos() == 0);
+
+        if buf.is_empty() {
+            // Special case when the buffer is completely empty. This indicates a missing TPI or IPI
+            // stream. In this case, `ItemInformation` acts like an empty shell that never resolves
+            // any types.
+            return Ok(Self::empty());
+        }
 
         let header = Header {
             version: buf.parse()?,

--- a/tests/id_information.rs
+++ b/tests/id_information.rs
@@ -1,0 +1,43 @@
+//! Tests that IdInformation works on files where the IPI is missing (empty stream).
+
+use std::path::Path;
+use std::sync::Once;
+
+use pdb::{FallibleIterator, IdIndex, PDB};
+
+static DOWNLOADED: Once = Once::new();
+fn open_file() -> std::fs::File {
+    let path = "fixtures/symbol_server/0ea7c70545374958ad3307514bdfc8642-wntdll.pdb";
+    let url = "https://msdl.microsoft.com/download/symbols/wntdll.pdb/0ea7c70545374958ad3307514bdfc8642/wntdll.pdb";
+
+    DOWNLOADED.call_once(|| {
+        if !Path::new(path).exists() {
+            let mut response = reqwest::get(url).expect("GET request");
+            let mut destination = std::fs::File::create(path).expect("create PDB");
+            response.copy_to(&mut destination).expect("download");
+        }
+    });
+
+    std::fs::File::open(path).expect("open PDB")
+}
+
+#[test]
+fn test_missing_ipi() {
+    let mut pdb = PDB::open(open_file()).expect("opening pdb");
+
+    let id_information = pdb.id_information().expect("get id information");
+
+    // Check ItemInformation API
+    assert_eq!(id_information.len(), 0);
+    assert!(id_information.is_empty());
+
+    // Check ItemIter API
+    let mut iter = id_information.iter();
+    assert!(iter.next().expect("iter empty IPI").is_none());
+
+    // Check ItemFinder API
+    let finder = id_information.finder();
+    assert_eq!(finder.max_index(), IdIndex(0));
+    finder.find(IdIndex(0)).expect_err("find index");
+    finder.find(IdIndex(4097)).expect_err("find index");
+}

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -1,6 +1,7 @@
-use pdb::{FallibleIterator, PdbInternalRva, PdbInternalSectionOffset, Rva};
 use std::path::Path;
 use std::sync::Once;
+
+use pdb::{FallibleIterator, PdbInternalRva, PdbInternalSectionOffset, Rva};
 
 // This test is intended to cover OMAP address translation:
 //   https://github.com/willglynn/pdb/issues/17


### PR DESCRIPTION
The ID stream may be completely empty if there are no ids in a PDB. Parsing the header fails in this case with an `UnexpectedEof` error, which is not clean. Instead, we can return an `Option` that explicitly indicates that there is no ID information available.