### PR TITLE
Return an Address map if section headers are missing

### DIFF
--- a/src/omap.rs
+++ b/src/omap.rs
@@ -405,7 +405,7 @@ impl FusedIterator for PdbInternalRvaRangeIter<'_> {}
 /// [`PdbInternalRva`]: struct.PdbInternalRva.html
 /// [`SectionOffset`]: struct.SectionOffset.html
 /// [`PdbInternalSectionOffset`]: struct.PdbInternalSectionOffset.html
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AddressMap<'s> {
     pub(crate) original_sections: Vec<ImageSectionHeader>,
     pub(crate) transformed_sections: Option<Vec<ImageSectionHeader>>,

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -389,7 +389,7 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// # test().unwrap()
     /// ```
     pub fn address_map(&mut self) -> Result<AddressMap<'s>> {
-        let sections = self.sections()?.ok_or_else(|| Error::AddressMapNotFound)?;
+        let sections = self.sections()?.unwrap_or_default();
         Ok(match self.original_sections()? {
             Some(original_sections) => {
                 let omap_from_src = self


### PR DESCRIPTION
Some PDBs seem to have no section headers, like for instance .NET Portable PDBs. In this case, `pdb.address_map()` used to return `Error::AddressMapNotFound`. It's slightly more ergonomic to return an empty address map for such a case, so that it can be used in `offset.to_rva(&address_map)` and the likes.

The case where `omap_from_src` and `omap_to_src` are missing is still returned as error, though.