### PR TITLE
Fix lines for MASM symbols

### DIFF
--- a/examples/pdb_lines.rs
+++ b/examples/pdb_lines.rs
@@ -35,7 +35,7 @@ fn dump_pdb(filename: &str) -> pdb::Result<()> {
                 let sign = if proc.global { "+" } else { "-" };
                 println!("{} {}", sign, proc.name);
 
-                let mut lines = program.lines_at_offset(proc.offset);
+                let mut lines = program.lines_for_symbol(proc.offset);
                 while let Some(line_info) = lines.next()? {
                     let rva = line_info.offset.to_rva(&address_map).expect("invalid rva");
                     let file_info = program.get_file_info(line_info.file_index)?;


### PR DESCRIPTION
`ProcedureSymbol` records for MASM functions have code ranges associated that do not match the actual code or line records. 

`lines_at_offset` assumed that if there is a lines subsection for a symbol, it shares the exact same start offset as the symbol. However, this is not the case for MASM functions, where the symbol's offset can lie *after* the actual start of the instructions / line records. Since the name of `lines_at_offset` was chosen badly, it is now renamed to `lines_for_symbol`, and explicitly states that it may return line records **outside** of the symbol's stated code range.

A consumer of this should probably collect the line records for each symbol and infer a proper code range.

Also, the internal implementation of `lines_at_offset` was slow in two regards: It had linear runtime complexity, and repeatedly had to iterate through large chunks of memory to find the appropriate section. `LineProgram` now collects and sorts all line sections ahead of time to perform faster binary search.

Fixes #61 
Fixes #63 
