### PR TITLE
Fixes compilation on rust 1.37.0

### DIFF
--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -392,9 +392,9 @@ pub fn open_msf<'s, S: Source<'s> + 's>(mut source: S) -> Result<Box<dyn MSF<'s,
         Err(e) => match e {
             Error::IoError(x) => {
                 if x.kind() == std::io::ErrorKind::UnexpectedEof {
-                    return Err(Error::UnrecognizedFileFormat)
+                    return Err(Error::UnrecognizedFileFormat);
                 } else {
-                    return Err(Error::IoError(x))
+                    return Err(Error::IoError(x));
                 }
             }
             _ => return Err(e),

--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -390,8 +390,12 @@ pub fn open_msf<'s, S: Source<'s> + 's>(mut source: S) -> Result<Box<dyn MSF<'s,
     let header_view = match view(&mut source, &header_location) {
         Ok(view) => view,
         Err(e) => match e {
-            Error::IoError(x) if x.kind() == std::io::ErrorKind::UnexpectedEof => {
-                return Err(Error::UnrecognizedFileFormat)
+            Error::IoError(x) => {
+                if x.kind() == std::io::ErrorKind::UnexpectedEof {
+                    return Err(Error::UnrecognizedFileFormat)
+                } else {
+                    return Err(Error::IoError(x))
+                }
             }
             _ => return Err(e),
         },


### PR DESCRIPTION
Compiling on rust 1.37.0 gives the following error:

```
error[E0008]: cannot bind by-move into a pattern guard
   --> src/msf/mod.rs:393:28
    |
393 |             Error::IoError(x) if x.kind() == std::io::ErrorKind::UnexpectedEof => {
    |                            ^ moves value into pattern guard

error: aborting due to previous error
```
Modifying the match statement slightly will let rust 1.37.0 as well as 1.40.0 compile the pdb crate successfully.