### PR TITLE
Update fallible-iterator and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,11 +538,11 @@ dependencies = [
 name = "pdb"
 version = "0.5.0"
 dependencies = [
- "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -765,11 +765,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scroll"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "security-framework"
@@ -1043,6 +1040,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,7 +1124,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
-"checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -1131,7 +1133,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -1188,7 +1190,7 @@ dependencies = [
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
+"checksum scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
 "checksum security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05"
 "checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1219,6 +1221,7 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0238db0c5b605dd1cf51de0f21766f97fba2645897024461d6a00c036819a768"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ exclude = [
 ]
 
 [dependencies]
-fallible-iterator = "0.1.6"
-scroll = "0.9.2"
-uuid = "0.7.2"
+fallible-iterator = "0.2.0"
+scroll = "0.10.1"
+uuid = "0.8.1"
 
 [dev-dependencies]
 # for examples/
-getopts = "0.2.18"
+getopts = "0.2.21"
 
 # for tests/
 reqwest = "0.9.10"

--- a/src/common.rs
+++ b/src/common.rs
@@ -250,9 +250,8 @@ macro_rules! impl_pread {
     ($type:ty) => {
         impl<'a> TryFromCtx<'a, Endian> for $type {
             type Error = scroll::Error;
-            type Size = usize;
 
-            fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+            fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, usize)> {
                 TryFromCtx::try_from_ctx(this, le).map(|(i, s)| (Self(i), s))
             }
         }
@@ -556,9 +555,8 @@ pub struct PdbInternalSectionOffset {
 
 impl<'t> TryFromCtx<'t, Endian> for PdbInternalSectionOffset {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = PdbInternalSectionOffset {
             offset: this.gread_with(&mut offset, le)?,
@@ -827,7 +825,7 @@ impl<'b> ParseBuffer<'b> {
     /// Parse an object that implements `Pread`.
     pub fn parse<T>(&mut self) -> Result<T>
     where
-        T: TryFromCtx<'b, Endian, [u8], Size = usize>,
+        T: TryFromCtx<'b, Endian, [u8]>,
         T::Error: From<scroll::Error>,
         Error: From<T::Error>,
     {
@@ -837,7 +835,7 @@ impl<'b> ParseBuffer<'b> {
     /// Parse an object that implements `Pread` with the given context.
     pub fn parse_with<T, C>(&mut self, ctx: C) -> Result<T>
     where
-        T: TryFromCtx<'b, C, [u8], Size = usize>,
+        T: TryFromCtx<'b, C, [u8]>,
         T::Error: From<scroll::Error>,
         Error: From<T::Error>,
         C: Copy,
@@ -944,9 +942,8 @@ impl fmt::Display for Variant {
 
 impl<'a> TryFromCtx<'a, Endian> for Variant {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'a [u8], le: Endian) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'a [u8], le: Endian) -> Result<(Self, usize)> {
         let mut offset = 0;
 
         let variant = match this.gread_with(&mut offset, le)? {

--- a/src/modi/c13.rs
+++ b/src/modi/c13.rs
@@ -56,9 +56,8 @@ struct DebugSubsectionHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for DebugSubsectionHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = DebugSubsectionHeader {
             kind: this.gread_with(&mut offset, le)?,
@@ -125,9 +124,8 @@ struct DebugInlineeLinesHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for DebugInlineeLinesHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = DebugInlineeLinesHeader {
             signature: this.gread_with(&mut offset, le)?,
@@ -156,9 +154,8 @@ impl<'a> InlineeSourceLine<'a> {
 
 impl<'a> TryFromCtx<'a, DebugInlineeLinesHeader> for InlineeSourceLine<'a> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'a [u8], header: DebugInlineeLinesHeader) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'a [u8], header: DebugInlineeLinesHeader) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
         let inlinee = buf.parse()?;
         let file_id = buf.parse()?;
@@ -239,9 +236,8 @@ struct DebugLinesHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for DebugLinesHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = DebugLinesHeader {
             offset: this.gread_with(&mut offset, le)?,
@@ -306,9 +302,8 @@ struct LineNumberHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for LineNumberHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = LineNumberHeader {
             offset: this.gread_with(&mut offset, le)?,
@@ -429,9 +424,8 @@ struct ColumnNumberEntry {
 
 impl<'t> TryFromCtx<'t, Endian> for ColumnNumberEntry {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = ColumnNumberEntry {
             start_column: this.gread_with(&mut offset, le)?,
@@ -478,9 +472,8 @@ struct DebugLinesBlockHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for DebugLinesBlockHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = DebugLinesBlockHeader {
             file_index: this.gread_with(&mut offset, le)?,
@@ -609,9 +602,8 @@ struct FileChecksumHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for FileChecksumHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = FileChecksumHeader {
             name_offset: this.gread_with(&mut offset, le)?,
@@ -772,7 +764,7 @@ impl<'a> CrossModuleImports<'a> {
     /// Loads `CrossModuleImports` from the debug subsections data.
     pub(crate) fn parse(data: &'a [u8]) -> Result<Self> {
         let import_data = DebugSubsectionIterator::new(data)
-            .find(|sec| sec.kind == DebugSubsectionKind::CrossScopeImports)?
+            .find(|sec| Ok(sec.kind == DebugSubsectionKind::CrossScopeImports))?
             .map(|sec| sec.data);
 
         match import_data {
@@ -841,9 +833,8 @@ struct RawCrossScopeExport {
 
 impl<'t> TryFromCtx<'t, Endian> for RawCrossScopeExport {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = RawCrossScopeExport {
             local: this.gread_with(&mut offset, le)?,
@@ -943,7 +934,7 @@ impl CrossModuleExports {
 
     pub(crate) fn parse(data: &[u8]) -> Result<Self> {
         let export_data = DebugSubsectionIterator::new(data)
-            .find(|sec| sec.kind == DebugSubsectionKind::CrossScopeExports)?
+            .find(|sec| Ok(sec.kind == DebugSubsectionKind::CrossScopeExports))?
             .map(|sec| sec.data);
 
         match export_data {
@@ -1231,7 +1222,7 @@ pub struct InlineeIterator<'a> {
 impl<'a> InlineeIterator<'a> {
     pub(crate) fn parse(data: &'a [u8]) -> Result<Self> {
         let inlinee_data = DebugSubsectionIterator::new(data)
-            .find(|sec| sec.kind == DebugSubsectionKind::InlineeLines)?
+            .find(|sec| Ok(sec.kind == DebugSubsectionKind::InlineeLines))?
             .map(|sec| sec.data);
 
         let inlinee_lines = match inlinee_data {
@@ -1287,7 +1278,7 @@ pub struct LineProgram<'a> {
 impl<'a> LineProgram<'a> {
     pub(crate) fn parse(data: &'a [u8]) -> Result<Self> {
         let checksums_data = DebugSubsectionIterator::new(data)
-            .find(|sec| sec.kind == DebugSubsectionKind::FileChecksums)?
+            .find(|sec| Ok(sec.kind == DebugSubsectionKind::FileChecksums))?
             .map(|sec| sec.data);
 
         let file_checksums = match checksums_data {
@@ -1315,9 +1306,9 @@ impl<'a> LineProgram<'a> {
         // quickly advance to the first (and only) subsection that matches that offset. Since they
         // are non-overlapping and not empty, we can bail out at the first match.
         let section = DebugSubsectionIterator::new(self.data)
-            .filter(|section| section.kind == DebugSubsectionKind::Lines)
-            .and_then(|section| DebugLinesSubsection::parse(section.data))
-            .find(|lines_section| lines_section.header.offset == offset);
+            .filter(|section| Ok(section.kind == DebugSubsectionKind::Lines))
+            .map(|section| DebugLinesSubsection::parse(section.data))
+            .find(|lines_section| Ok(lines_section.header.offset == offset));
 
         match section {
             Ok(Some(section)) => LineIterator {

--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -92,9 +92,8 @@ mod big {
 
     impl<'t> TryFromCtx<'t, Endian> for RawHeader {
         type Error = scroll::Error;
-        type Size = usize;
 
-        fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+        fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
             let mut offset = 0;
             let data = RawHeader {
                 magic: {

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -49,9 +49,8 @@ struct StringTableHeader {
 
 impl<'t> TryFromCtx<'t, Endian> for StringTableHeader {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let mut offset = 0;
         let data = StringTableHeader {
             magic: this.gread_with(&mut offset, le)?,

--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -471,9 +471,8 @@ impl From<u16> for CPUType {
 
 impl<'a> TryFromCtx<'a, Endian> for CPUType {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         u16::try_from_ctx(this, le).map(|(v, l)| (v.into(), l))
     }
 }
@@ -558,9 +557,8 @@ impl From<u8> for SourceLanguage {
 
 impl<'a> TryFromCtx<'a, Endian> for SourceLanguage {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'a [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         u8::try_from_ctx(this, le).map(|(v, l)| (v.into(), l))
     }
 }

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -232,9 +232,8 @@ impl<'t> SymbolData<'t> {
 
 impl<'t> TryFromCtx<'t> for SymbolData<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], _ctx: ()) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], _ctx: ()) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
         let kind = buf.parse()?;
 
@@ -301,9 +300,8 @@ pub struct RegisterVariableSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for RegisterVariableSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = RegisterVariableSymbol {
@@ -329,9 +327,8 @@ pub struct MultiRegisterVariableSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for MultiRegisterVariableSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let type_index = buf.parse()?;
@@ -381,9 +378,8 @@ pub struct PublicSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for PublicSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let flags = buf.parse::<u32>()?;
@@ -423,9 +419,8 @@ pub struct DataSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for DataSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let global = match kind {
@@ -470,9 +465,8 @@ pub struct ProcedureReferenceSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ProcedureReferenceSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let global = match kind {
@@ -511,9 +505,8 @@ pub struct DataReferenceSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for DataReferenceSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = DataReferenceSymbol {
@@ -546,9 +539,8 @@ pub struct AnnotationReferenceSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for AnnotationReferenceSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = AnnotationReferenceSymbol {
@@ -579,9 +571,8 @@ pub struct ConstantSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ConstantSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = ConstantSymbol {
@@ -608,9 +599,8 @@ pub struct UserDefinedTypeSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for UserDefinedTypeSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = UserDefinedTypeSymbol {
@@ -641,9 +631,8 @@ pub struct ThreadStorageSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ThreadStorageSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let global = match kind {
@@ -695,9 +684,8 @@ pub struct ProcedureFlags {
 
 impl<'t> TryFromCtx<'t, Endian> for ProcedureFlags {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let (value, size) = u8::try_from_ctx(this, le)?;
 
         let flags = ProcedureFlags {
@@ -756,9 +744,8 @@ pub struct ProcedureSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ProcedureSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let global = match kind {
@@ -813,9 +800,8 @@ pub struct InlineSiteSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for InlineSiteSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = InlineSiteSymbol {
@@ -844,9 +830,8 @@ pub struct BuildInfoSymbol {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for BuildInfoSymbol {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], _kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = BuildInfoSymbol { id: buf.parse()? };
@@ -868,9 +853,8 @@ pub struct ObjNameSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ObjNameSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = ObjNameSymbol {
@@ -897,9 +881,8 @@ pub struct CompilerVersion {
 
 impl<'t> TryFromCtx<'t, bool> for CompilerVersion {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], has_qfe: bool) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], has_qfe: bool) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let version = CompilerVersion {
@@ -944,9 +927,8 @@ pub struct CompileFlags {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for CompileFlags {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let is_compile3 = kind == S_COMPILE3;
 
         let raw = this.pread_with::<u16>(0, LE)?;
@@ -993,9 +975,8 @@ pub struct CompileFlagsSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for CompileFlagsSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let has_qfe = kind == S_COMPILE3;
@@ -1023,9 +1004,8 @@ pub struct UsingNamespaceSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for UsingNamespaceSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = UsingNamespaceSymbol {
@@ -1076,9 +1056,8 @@ pub struct LocalVariableFlags {
 
 impl<'t> TryFromCtx<'t, Endian> for LocalVariableFlags {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let (value, size) = u16::try_from_ctx(this, le)?;
 
         let flags = LocalVariableFlags {
@@ -1113,9 +1092,8 @@ pub struct LocalSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for LocalSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = LocalSymbol {
@@ -1148,9 +1126,8 @@ pub struct ExportSymbolFlags {
 
 impl<'t> TryFromCtx<'t, Endian> for ExportSymbolFlags {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let (value, size) = u16::try_from_ctx(this, le)?;
 
         let flags = ExportSymbolFlags {
@@ -1181,9 +1158,8 @@ pub struct ExportSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ExportSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = ExportSymbol {
@@ -1211,9 +1187,8 @@ pub struct LabelSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for LabelSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = LabelSymbol {
@@ -1245,9 +1220,8 @@ pub struct BlockSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for BlockSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = BlockSymbol {
@@ -1281,9 +1255,8 @@ pub struct RegisterRelativeSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for RegisterRelativeSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let symbol = RegisterRelativeSymbol {
@@ -1344,9 +1317,8 @@ pub struct ThunkSymbol<'t> {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for ThunkSymbol<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let parent = parse_optional_index(&mut buf)?;
@@ -1398,9 +1370,8 @@ pub struct SeparatedCodeFlags {
 
 impl<'t> TryFromCtx<'t, Endian> for SeparatedCodeFlags {
     type Error = scroll::Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> scroll::Result<(Self, usize)> {
         let (value, size) = u32::try_from_ctx(this, le)?;
 
         let flags = SeparatedCodeFlags {
@@ -1433,9 +1404,8 @@ pub struct SeparatedCodeSymbol {
 
 impl<'t> TryFromCtx<'t, SymbolKind> for SeparatedCodeSymbol {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], _: SymbolKind) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], _: SymbolKind) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
 
         let parent = buf.parse()?;

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -41,9 +41,8 @@ impl<'t> IdData<'t> {}
 
 impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
     type Error = Error;
-    type Size = usize;
 
-    fn try_from_ctx(this: &'t [u8], _ctx: scroll::Endian) -> Result<(Self, Self::Size)> {
+    fn try_from_ctx(this: &'t [u8], _ctx: scroll::Endian) -> Result<(Self, usize)> {
         let mut buf = ParseBuffer::from(this);
         let leaf = buf.parse_u16()?;
 

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -33,10 +33,12 @@ fn test_omap_symbol() {
         let target_name = pdb::RawString::from("NtWaitForSingleObject");
         let mut iter = global_symbols.iter();
         iter.find(|sym| {
-            sym.parse()
+            let matches = sym
+                .parse()
                 .ok()
                 .and_then(|d| d.name())
-                .map_or(false, |n| n == target_name)
+                .map_or(false, |n| n == target_name);
+            Ok(matches)
         })
         .expect("iterate symbols")
         .expect("find target symbol")


### PR DESCRIPTION
Breaking change: `fallible-iterator` is updated to 0.2.0, which is now more widely used.

Also updates `uuid` and `scoll` internally.