### PR TITLE
Disregard section zero when performing OMAP translation

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use crate::common::*;
 
 /// A PE `IMAGE_SECTION_HEADER`, as described in [the Microsoft documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx).
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct ImageSectionHeader {
     /// An 8-byte, null-padded UTF-8 string. There is no terminating null character if the string is
     /// exactly eight characters long. For longer names, this member contains a forward slash (`/`)

--- a/tests/omap_address_translation.rs
+++ b/tests/omap_address_translation.rs
@@ -23,6 +23,22 @@ fn open_file() -> std::fs::File {
 }
 
 #[test]
+fn test_omap_section_zero() {
+    // https://github.com/willglynn/pdb/issues/87
+
+    let mut pdb = pdb::PDB::open(open_file()).expect("opening pdb");
+
+    let address = pdb::PdbInternalSectionOffset {
+        offset: 0,
+        section: 0x1234,
+    };
+
+    let address_map = pdb.address_map().expect("address map");
+
+    assert_eq!(address.to_rva(&address_map), None);
+}
+
+#[test]
 fn test_omap_symbol() {
     let mut pdb = pdb::PDB::open(open_file()).expect("opening pdb");
 


### PR DESCRIPTION
Section 0 isn't a real section, but it appears in real PDBs. Right now we panic when we should just return `None`. Fixes #87.