### PR TITLE
Re-export public enums located in private `constants` crate

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -245,7 +245,7 @@ impl DBIHeader {
 }
 
 /// The target machine's architecture.
-/// Reference: https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#machine-types
+/// Reference: <https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#machine-types>
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MachineType {
     /// The contents of this field are assumed to be applicable to any machine type.

--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -269,7 +269,7 @@ pub const S_GDATA_HLSL32_EX: u16 = 0x1164;
 pub const S_LDATA_HLSL32_EX: u16 = 0x1165;
 
 /// These values correspond to the CV_CPU_TYPE_e enumeration, and are documented
-/// here: https://msdn.microsoft.com/en-us/library/b2fc64ek.aspx
+/// [on MSDN](https://msdn.microsoft.com/en-us/library/b2fc64ek.aspx).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CPUType {
     Intel8080 = 0x0,
@@ -478,7 +478,7 @@ impl<'a> TryFromCtx<'a, Endian> for CPUType {
 }
 
 /// These values correspond to the CV_CFL_LANG enumeration, and are documented
-/// here: https://msdn.microsoft.com/en-us/library/bw3aekw6.aspx
+/// [on MSDN](https://msdn.microsoft.com/en-us/library/bw3aekw6.aspx).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SourceLanguage {
     C = 0x00,

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -17,6 +17,7 @@ mod annotations;
 mod constants;
 
 use self::constants::*;
+pub use self::constants::{CPUType, SourceLanguage};
 
 pub use self::annotations::*;
 


### PR DESCRIPTION
This change allows rustdoc to index `CPUType` and `SourceLanguage` types (see #89 for more info). While I was examining the rustdoc output I noticed that there were a few URLs not properly hyperlinked, so I fixed those aswell.