### PR TITLE
Mark certain types as non_exhaustive

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -19,6 +19,7 @@ use scroll::{self, Endian, Pread, LE};
 use crate::tpi::constants;
 
 /// An error that occurred while reading or parsing the PDB.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
     /// The input data was not recognized as a MSF (PDB) file.

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -112,6 +112,7 @@ impl<'s> DebugInformation<'s> {
 /// The version of the PDB format.
 ///
 /// This version type is used in multiple locations: the DBI header, and the PDBI header.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 #[allow(missing_docs)]
 pub enum HeaderVersion {
@@ -246,6 +247,7 @@ impl DBIHeader {
 
 /// The target machine's architecture.
 /// Reference: <https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#machine-types>
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MachineType {
     /// The contents of this field are assumed to be applicable to any machine type.

--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -270,6 +270,7 @@ pub const S_LDATA_HLSL32_EX: u16 = 0x1165;
 
 /// These values correspond to the CV_CPU_TYPE_e enumeration, and are documented
 /// [on MSDN](https://msdn.microsoft.com/en-us/library/b2fc64ek.aspx).
+#[non_exhaustive]
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CPUType {
@@ -480,6 +481,7 @@ impl<'a> TryFromCtx<'a, Endian> for CPUType {
 
 /// These values correspond to the CV_CFL_LANG enumeration, and are documented
 /// [on MSDN](https://msdn.microsoft.com/en-us/library/bw3aekw6.aspx).
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SourceLanguage {
     /// Application language is C.

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -164,6 +164,7 @@ fn parse_optional_index(buf: &mut ParseBuffer<'_>) -> Result<Option<SymbolIndex>
 //   https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/cvdump/dumpsym7.cpp#L264
 
 /// Information parsed from a [`Symbol`] record.
+#[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SymbolData<'t> {
     /// End of a scope, such as a procedure.
@@ -670,6 +671,7 @@ const CV_PFLAG_NOINLINE: u8 = 0x40;
 const CV_PFLAG_OPTDBGINFO: u8 = 0x80;
 
 /// Flags of a [`ProcedureSymbol`](struct.ProcedureSymbol).
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProcedureFlags {
     /// Frame pointer is present (not omitted).
@@ -893,6 +895,7 @@ impl<'t> TryFromCtx<'t, bool> for CompilerVersion {
 }
 
 /// Compile flags declared in `CompileFlagsSymbol`.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CompileFlags {
     /// Compiled for edit and continue.
@@ -1025,6 +1028,7 @@ const CV_LVARFLAG_ISENREG_GLOB: u16 = 0x100;
 const CV_LVARFLAG_ISENREG_STAT: u16 = 0x200;
 
 /// Flags for a [`LocalSymbol`].
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LocalVariableFlags {
     /// Variable is a parameter.
@@ -1104,6 +1108,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for LocalSymbol<'t> {
 
 // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4456
 /// Flags of an [`ExportSymbol`].
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ExportSymbolFlags {
     /// An exported constant.
@@ -1274,6 +1279,7 @@ pub struct ThunkAdjustor<'t> {
 }
 
 /// A thunk kind
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ThunkKind<'t> {
     /// Standard thunk
@@ -1356,6 +1362,7 @@ const CV_SEPCODEFLAG_IS_LEXICAL_SCOPE: u32 = 0x01;
 const CV_SEPCODEFLAG_RETURNS_TO_PARENT: u32 = 0x02;
 
 /// Flags for a [`SeparatedCodeSymbol`].
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SeparatedCodeFlags {
     /// S_SEPCODE doubles as lexical scope.

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -12,6 +12,7 @@ use crate::tpi::constants::*;
 use crate::tpi::primitive::*;
 
 /// Encapsulates parsed data about a `Type`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeData<'t> {
     Primitive(PrimitiveType),

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -21,6 +21,7 @@ fn parse_string<'t>(leaf: u16, buf: &mut ParseBuffer<'t>) -> Result<RawString<'t
 }
 
 /// Encapsulates parsed data about an `Id`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdData<'t> {
     /// Global function, usually inlined.

--- a/src/tpi/primitive.rs
+++ b/src/tpi/primitive.rs
@@ -33,6 +33,7 @@ pub struct PrimitiveType {
 }
 
 /// A simple type.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PrimitiveKind {
     /// Uncharacterized type (no type)


### PR DESCRIPTION
Some of our types - especially enumerations - are either known to be extensible, incomplete, or not meant to be matched exhaustively. This PR adds `#[non-exhaustive]` annotations to these types to allow changing them in upcoming versions without breaking the API.

Fixes https://github.com/willglynn/pdb/issues/94