### PR TITLE
Parse module references in symbol data

### DIFF
--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -477,8 +477,10 @@ pub struct ProcedureReferenceSymbol<'t> {
     ///
     /// Note that this symbol might be located in a different module.
     pub symbol_index: SymbolIndex,
-    /// Index of the module containing the actual symbol.
-    pub module: u16,
+    /// Index of the module in [`DebugInformation::modules`] containing the actual symbol.
+    ///
+    /// [`DebugInformation::modules`]: struct.DebugInformation.html#method.modules
+    pub module: Option<usize>,
     /// Name of the procedure reference.
     pub name: Option<RawString<'t>>,
 }
@@ -493,7 +495,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for ProcedureReferenceSymbol<'t> {
             global: matches!(kind, S_PROCREF | S_PROCREF_ST),
             sum_name: buf.parse()?,
             symbol_index: buf.parse()?,
-            module: buf.parse()?,
+            module: buf.parse::<u16>()?.checked_sub(1).map(usize::from),
             name: parse_optional_name(&mut buf, kind)?,
         };
 
@@ -512,8 +514,10 @@ pub struct DataReferenceSymbol<'t> {
     ///
     /// Note that this symbol might be located in a different module.
     pub symbol_index: SymbolIndex,
-    /// Index of the module containing the actual symbol.
-    pub module: u16,
+    /// Index of the module in [`DebugInformation::modules`] containing the actual symbol.
+    ///
+    /// [`DebugInformation::modules`]: struct.DebugInformation.html#method.modules
+    pub module: Option<usize>,
     /// Name of the data reference.
     pub name: Option<RawString<'t>>,
 }
@@ -527,7 +531,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for DataReferenceSymbol<'t> {
         let symbol = DataReferenceSymbol {
             sum_name: buf.parse()?,
             symbol_index: buf.parse()?,
-            module: buf.parse()?,
+            module: buf.parse::<u16>()?.checked_sub(1).map(usize::from),
             name: parse_optional_name(&mut buf, kind)?,
         };
 
@@ -546,8 +550,10 @@ pub struct AnnotationReferenceSymbol<'t> {
     ///
     /// Note that this symbol might be located in a different module.
     pub symbol_index: SymbolIndex,
-    /// Index of the module containing the actual symbol.
-    pub module: u16,
+    /// Index of the module in [`DebugInformation::modules`] containing the actual symbol.
+    ///
+    /// [`DebugInformation::modules`]: struct.DebugInformation.html#method.modules
+    pub module: Option<usize>,
     /// Name of the annotation reference.
     pub name: RawString<'t>,
 }
@@ -561,7 +567,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for AnnotationReferenceSymbol<'t> {
         let symbol = AnnotationReferenceSymbol {
             sum_name: buf.parse()?,
             symbol_index: buf.parse()?,
-            module: buf.parse()?,
+            module: buf.parse::<u16>()?.checked_sub(1).map(usize::from),
             name: parse_symbol_name(&mut buf, kind)?,
         };
 
@@ -1761,7 +1767,7 @@ mod tests {
                     global: true,
                     sum_name: 0,
                     symbol_index: SymbolIndex(108),
-                    module: 1,
+                    module: Some(0),
                     name: Some("Baz::f_public".into()),
                 })
             );
@@ -1875,7 +1881,7 @@ mod tests {
                     global: false,
                     sum_name: 0,
                     symbol_index: SymbolIndex(1152),
-                    module: 182,
+                    module: Some(181),
                     name: Some("capture_current_context".into()),
                 })
             );


### PR DESCRIPTION
This is an attempt to provide a better API for module references in symbol data. My initial findings were described in https://github.com/willglynn/pdb/issues/89#issuecomment-719528757:

> * Code for resolving a module reference can be seen [here](https://github.com/Microsoft/microsoft-pdb/blob/1bdc5900390b6edec02e7b6a1b6e7bdef6e76df1/PDB/dbi/dbi.cpp#L2694).
> * This subtracts 1 via [`imodForXimod `](https://github.com/Microsoft/microsoft-pdb/blob/e6b1dec61e154b568357537792e1d17a13525d5d/PDB/include/dbicommon.h#L9) to get a 0-based index. I'm assuming a literal 0 means no reference.
> * [`openModByImod`](https://github.com/Microsoft/microsoft-pdb/blob/1bdc5900390b6edec02e7b6a1b6e7bdef6e76df1/PDB/dbi/dbi.cpp#L1284) then runs `pmodiForImod`.
> * [`pmodiForImod`](https://github.com/Microsoft/microsoft-pdb/blob/1bdc5900390b6edec02e7b6a1b6e7bdef6e76df1/PDB/dbi/dbi.h#L771-L774) indexes into `rgpmodi`.
> * `rgpmodi` is built sequentially [here](https://github.com/Microsoft/microsoft-pdb/blob/1bdc5900390b6edec02e7b6a1b6e7bdef6e76df1/PDB/dbi/dbi.cpp#L502-L525).
> 
> So I think it should be safe to assume that you can take `dbi.modules().nth(proc_ref.module - 1)`.

In this implementation, I'm taking the safe route and parsing this into an `Option<usize>` instead of erroring, but I'm not sure if that's even necessary. Most likely, a value of `0` is invalid an a reference symbol, so we could also error out instead of making this an Option.

Can someone validate my assumptions?