### PR TITLE
Adopt intra doc links and fix broken docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,8 @@ matrix:
     - name: clippy
       install: rustup component add clippy
       script: cargo clippy --all-features --tests --all --examples -- -D clippy::all
+    - name: docs
+      script: cargo doc --no-deps --all-features
+      env: RUSTDOCFLAGS=-Dbroken_intra_doc_links
   allow_failures:
     - rust: nightly

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -73,14 +73,14 @@ impl<'s> DebugInformation<'s> {
 
     /// Returns this PDB's original `age`.
     ///
-    /// This number is written by the linker and should be equal to the image's `age` value.
-    /// In contrast, [`PDBInformation::age`] may be bumped by other tools and should be greater or
+    /// This number is written by the linker and should be equal to the image's `age` value. In
+    /// contrast, [`PDBInformation::age`] may be bumped by other tools and should be greater or
     /// equal to the image's `age` value.
     ///
     /// Old PDB files may not specify an age, in which case only [`PDBInformation::age`] should be
     /// checked for matching the image.
     ///
-    /// [`PDBInformation::age`]: struct.PDBInformation.html#structfield.age
+    /// [`PDBInformation::age`]: crate::PDBInformation::age
     pub fn age(&self) -> Option<u32> {
         match self.header.age {
             0 => None,
@@ -379,8 +379,9 @@ pub struct DBISectionContribution {
     /// The size of the contribution, in bytes.
     pub size: u32,
     /// The characteristics, which map to the `Characteristics` field of
-    /// the [`IMAGE_SECTION_HEADER`][1] field in binaries.
-    /// [1]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx
+    /// the [`IMAGE_SECTION_HEADER`] field in binaries.
+    ///
+    /// [`IMAGE_SECTION_HEADER`]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx
     pub characteristics: u32,
     /// The index of the module.
     pub module: u16,
@@ -464,13 +465,11 @@ impl DBIModuleInfo {
 
 /// Represents a module from the DBI stream.
 ///
-/// A `Module` is a single item that contributes to the binary, such as an
-/// object file or import library.
+/// A `Module` is a single item that contributes to the binary, such as an object file or import
+/// library.
 ///
-/// Much of the useful information for a `Module` is stored in a separate stream in the PDB.
-/// It can be retrieved by calling [`PDB::module_info`] with a specific module.
-///
-/// [`PDB::module_info`]: struct.PDB.html#method.module_info
+/// Much of the useful information for a `Module` is stored in a separate stream in the PDB. It can
+/// be retrieved by calling [`PDB::module_info`](crate::PDB::module_info) with a specific module.
 #[derive(Debug, Clone)]
 pub struct Module<'m> {
     info: DBIModuleInfo,

--- a/src/framedata.rs
+++ b/src/framedata.rs
@@ -174,7 +174,6 @@ impl fmt::Debug for NewFrameData {
 /// stream might describe the same RVA.
 ///
 /// [`struct _FPO_DATA`]: https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#debug-type
-/// [`NewFrameData`]: struct.NewFrameData.html
 ///
 /// ```c
 /// typedef struct _FPO_DATA {
@@ -274,10 +273,7 @@ pub struct FrameData {
     /// Relative virtual address of the start of the code block.
     ///
     /// Note that this address is internal to the PDB. To convert this to an actual [`Rva`], use
-    /// [`to_rva`].
-    ///
-    /// [`Rva`]: struct.Rva.html
-    /// [`to_rva`]: struct.PdbInternalRva.html#method.to_rva
+    /// [`PdbInternalRva::to_rva`].
     pub code_start: PdbInternalRva,
 
     /// Size of the code block covered by this frame data in bytes.
@@ -362,7 +358,7 @@ impl From<&'_ NewFrameData> for FrameData {
     }
 }
 
-/// Iterator over entries in a [`FrameTable`](struct.FrameTable.html).
+/// Iterator over entries in a [`FrameTable`].
 #[derive(Debug, Default)]
 pub struct FrameDataIter<'t> {
     old_frames: &'t [OldFrameData],
@@ -472,7 +468,7 @@ fn binary_search_by_rva<R: AddrRange>(frames: &[R], rva: PdbInternalRva) -> usiz
 ///
 /// A procedure/function might be described by multiple entries, with the first one declaring
 /// `is_function_start`. To retrieve frame information for a specific function, use
-/// [`FrameTable::at_rva`].
+/// [`FrameTable::iter_at_rva`].
 ///
 /// Not every function in the image file must have frame data defined for it. Those functions that
 /// do not have frame data are assumed to have normal stack frames.
@@ -544,11 +540,8 @@ impl<'s> FrameTable<'s> {
     /// frame data covers the given RVA, the iterator starts at the first item **after** the RVA.
     /// Therefore, check for the desired RVA range when iterating frame data.
     ///
-    /// To obtain a `PdbInternalRva`, use the `to_internal_rva` methods on
-    /// [`PdbInternalSectionOffset`] or [`Rva`].
-    ///
-    /// [`PdbInternalSectionOffset`]: struct.PdbInternalSectionOffset.html
-    /// [`Rva`]: struct.Rva.html
+    /// To obtain a `PdbInternalRva`, use [`PdbInternalSectionOffset::to_internal_rva`] or
+    /// [`Rva::to_internal_rva`].
     pub fn iter_at_rva(&self, rva: PdbInternalRva) -> FrameDataIter<'_> {
         let old_frames = self.old_frames();
         let old_index = binary_search_by_rva(old_frames, rva);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Usage
 //!
-//! PDB files are accessed via the [`pdb::PDB` object](struct.PDB.html).
+//! PDB files are accessed via the [`pdb::PDB`] object.
 //!
 //! # Example
 //!

--- a/src/modi/c13.rs
+++ b/src/modi/c13.rs
@@ -893,8 +893,7 @@ impl<'a> DebugCrossScopeExportsSubsection<'a> {
     }
 }
 
-/// Iterator returned by
-/// [`CrossModuleExports::exports`](struct.CrossModuleExports.html#method.exports).
+/// Iterator returned by [`CrossModuleExports::exports`].
 #[derive(Clone, Debug)]
 pub struct CrossModuleExportIter<'a> {
     exports: slice::Iter<'a, RawCrossScopeExport>,
@@ -917,9 +916,8 @@ impl<'a> FallibleIterator for CrossModuleExportIter<'a> {
 
 /// A table of exports declared by this module.
 ///
-/// Other modules can import types and ids from this module by using [cross module references].
-///
-/// [cross module references]: trait.ItemIndex.html#method.is_cross_module
+/// Other modules can import types and ids from this module by using [cross module
+/// references](ItemIndex::is_cross_module).
 #[derive(Clone, Debug, Default)]
 pub struct CrossModuleExports {
     raw_exports: Vec<RawCrossScopeExport>,
@@ -963,9 +961,10 @@ impl CrossModuleExports {
 
     /// Resolves the global index of the given cross module import's local index.
     ///
-    /// The global index can be used to retrieve items from the [`TypeInformation`] or
-    /// [`IdInformation`] streams. If the given local index is not listed in the export list, this
-    /// function returns `Ok(None)`.
+    /// The global index can be used to retrieve items from the
+    /// [`TypeInformation`](crate::TypeInformation) or [`IdInformation`](crate::IdInformation)
+    /// streams. If the given local index is not listed in the export list, this function returns
+    /// `Ok(None)`.
     pub fn resolve_import<I>(&self, local_index: Local<I>) -> Result<Option<I>>
     where
         I: ItemIndex,

--- a/src/modi/mod.rs
+++ b/src/modi/mod.rs
@@ -143,7 +143,7 @@ impl PartialEq for FileChecksum<'_> {
 /// Information record on a source file.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FileInfo<'a> {
-    /// Reference to the file name in the [string table](struct.StringTable.html).
+    /// Reference to the file name in the [`StringTable`](crate::StringTable).
     pub name: StringRef,
 
     /// Checksum of the file contents.
@@ -313,12 +313,8 @@ impl<'a> FallibleIterator for FileIterator<'a> {
 
 /// Named reference to a [`Module`].
 ///
-/// The name stored in the [`StringTable`] corresponds to the name of the module as returned by
-/// [`Module::module_name`].
-///
-/// [`Module`]: struct.Module.html
-/// [`Module::module_name`]: struct.Module.html#method.module_name
-/// [`StringTable`]: struct.StringTable.html
+/// The name stored in the [`StringTable`](crate::StringTable) corresponds to the name of the module
+/// as returned by [`Module::module_name`].
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ModuleRef(pub StringRef);
 
@@ -331,8 +327,6 @@ impl fmt::Display for ModuleRef {
 /// Reference to a local type or id in another module.
 ///
 /// See [`ItemIndex::is_cross_module`] for more information.
-///
-/// [`ItemIndex::is_cross_module`]: trait.ItemIndex.html#method.is_cross_module
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct CrossModuleRef<I: ItemIndex>(pub ModuleRef, pub Local<I>);
 
@@ -342,8 +336,8 @@ pub struct CrossModuleRef<I: ItemIndex>(pub ModuleRef, pub Local<I>);
 /// imports subsection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CrossModuleExport {
-    /// A cross module export of a [`Type`](type.Type.html).
+    /// A cross module export of a [`Type`](crate::Type).
     Type(Local<TypeIndex>, TypeIndex),
-    /// A cross module export of an [`Id`](type.Id.html).
+    /// A cross module export of an [`Id`](crate::Id).
     Id(Local<IdIndex>, IdIndex),
 }

--- a/src/omap.rs
+++ b/src/omap.rs
@@ -117,8 +117,7 @@ impl Ord for OMAPRecord {
 /// storing target addresses), but given that OMAP tables are an uncommon PDBs feature, the obvious
 /// binary search implementation seems appropriate.
 ///
-/// [module level documentation]: ./index.html
-/// [`AddressMap`]: struct.AddressMap.html
+/// [module level documentation]: self
 pub(crate) struct OMAPTable<'s> {
     stream: Stream<'s>,
 }
@@ -272,10 +271,7 @@ impl Iterator for RangeIter<'_> {
 
 impl FusedIterator for RangeIter<'_> {}
 
-/// Iterator over [`Rva`] ranges returned by [`rva_ranges`].
-///
-/// [`Rva`]: struct.Rva.html
-/// [`rva_ranges`]: struct.AddressMap.html#method.rva_ranges
+/// Iterator over [`Rva`] ranges returned by [`AddressMap::rva_ranges`].
 pub struct RvaRangeIter<'t>(RangeIter<'t>);
 
 impl Iterator for RvaRangeIter<'_> {
@@ -288,10 +284,7 @@ impl Iterator for RvaRangeIter<'_> {
 
 impl FusedIterator for RvaRangeIter<'_> {}
 
-/// Iterator over [`InternalPdbRva`] ranges returned by [`internal_rva_ranges`].
-///
-/// [`InternalPdbRva`]: struct.InternalPdbRva.html
-/// [`internal_rva_ranges`]: struct.AddressMap.html#method.internal_rva_ranges
+/// Iterator over [`PdbInternalRva`] ranges returned by [`AddressMap::internal_rva_ranges`].
 pub struct PdbInternalRvaRangeIter<'t>(RangeIter<'t>);
 
 impl Iterator for PdbInternalRvaRangeIter<'_> {
@@ -394,10 +387,6 @@ impl FusedIterator for PdbInternalRvaRangeIter<'_> {}
 /// [Vulcan research project]: https://research.microsoft.com/pubs/69850/tr-2001-50.pdf
 /// [Microsoft Binary Technologies Projects]: https://microsoft.com/windows/cse/bit_projects.mspx
 /// [1997 reference material]: https://www.microsoft.com/msj/0597/hood0597.aspx
-/// [`Rva`]: struct.Rva.html
-/// [`PdbInternalRva`]: struct.PdbInternalRva.html
-/// [`SectionOffset`]: struct.SectionOffset.html
-/// [`PdbInternalSectionOffset`]: struct.PdbInternalSectionOffset.html
 #[derive(Debug, Default)]
 pub struct AddressMap<'s> {
     pub(crate) original_sections: Vec<ImageSectionHeader>,
@@ -469,9 +458,7 @@ impl Rva {
     /// Resolves the section offset in the PE headers.
     ///
     /// This is an offset into PE section headers of the executable. To retrieve section offsets
-    /// used in the PDB, use [`to_internal_offset`] instead.
-    ///
-    /// [`to_internal_offset`]: struct.Rva.html#method.to_internal_offset
+    /// used in the PDB, use [`to_internal_offset`](Self::to_internal_offset) instead.
     pub fn to_section_offset(self, translator: &AddressMap<'_>) -> Option<SectionOffset> {
         let (section, offset) = match translator.transformed_sections {
             Some(ref sections) => get_section_offset(sections, self.0)?,
@@ -484,9 +471,7 @@ impl Rva {
     /// Resolves the PDB internal section offset.
     ///
     /// This is the offset value used in the PDB file. To index into the actual PE section headers,
-    /// use [`to_section_offset`] instead.
-    ///
-    /// [`to_section_offset`]: struct.Rva.html#method.to_section_offset
+    /// use [`to_section_offset`](Self::to_section_offset) instead.
     pub fn to_internal_offset(
         self,
         translator: &AddressMap<'_>,
@@ -508,9 +493,7 @@ impl PdbInternalRva {
     /// Resolves the section offset in the PE headers.
     ///
     /// This is an offset into PE section headers of the executable. To retrieve section offsets
-    /// used in the PDB, use [`to_internal_offset`] instead.
-    ///
-    /// [`to_internal_offset`]: struct.PdbInternalRva.html#method.to_internal_offset
+    /// used in the PDB, use [`to_internal_offset`](Self::to_internal_offset) instead.
     pub fn to_section_offset(self, translator: &AddressMap<'_>) -> Option<SectionOffset> {
         self.to_rva(translator)?.to_section_offset(translator)
     }
@@ -518,9 +501,7 @@ impl PdbInternalRva {
     /// Resolves the PDB internal section offset.
     ///
     /// This is the offset value used in the PDB file. To index into the actual PE section headers,
-    /// use [`to_section_offset`] instead.
-    ///
-    /// [`to_section_offset`]: struct.Rva.html#method.to_section_offset
+    /// use [`to_section_offset`](Self::to_section_offset) instead.
     pub fn to_internal_offset(
         self,
         translator: &AddressMap<'_>,

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -18,8 +18,8 @@ use crate::strings::StringTable;
 use crate::symbol::SymbolTable;
 use crate::tpi::{IdInformation, TypeInformation};
 
-/// Some streams have a fixed stream index.
-/// http://llvm.org/docs/PDB/index.html
+// Some streams have a fixed stream index.
+// http://llvm.org/docs/PDB/index.html
 
 const PDB_STREAM: u32 = 1;
 const TPI_STREAM: u32 = 2;
@@ -180,17 +180,17 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
 
     /// Retrieve the module info stream for a specific `Module`.
     ///
-    /// Some information for each module is stored in a separate stream per-module.
-    /// `Module`s can be retrieved from the `PDB` by first calling [`debug_information`] to
-    /// get the debug information stream, and then calling [`modules`] on that.
+    /// Some information for each module is stored in a separate stream per-module. `Module`s can be
+    /// retrieved from the `PDB` by first calling [`debug_information`](Self::debug_information) to
+    /// get the debug information stream, and then calling [`modules`](DebugInformation::modules) on
+    /// that.
     ///
     /// # Errors
     ///
     /// * `Error::StreamNotFound` if the PDB does not contain this module info stream
     /// * `Error::IoError` if returned by the `Source`
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
-    /// * `Error::UnimplementedFeature` if the module information stream is an unsupported
-    ///   version
+    /// * `Error::UnimplementedFeature` if the module information stream is an unsupported version
     ///
     /// # Example
     ///
@@ -214,9 +214,6 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`debug_information`]: #method.debug_information
-    /// [`modules`]: struct.DebugInformation.html#method.modules
     pub fn module_info<'m>(&mut self, module: &Module<'m>) -> Result<Option<ModuleInfo<'s>>> {
         match self.raw_stream(module.info().stream)? {
             Some(stream) => ModuleInfo::parse(stream, module).map(Some),
@@ -355,8 +352,6 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// * `Error::StreamNotFound` if the PDB somehow does not contain a debug information stream
     /// * `Error::UnimplementedFeature` if the debug information header predates ~1995
     ///
-    /// [`AddressMap`]: struct.AddressMap.html
-    ///
     /// # Example
     ///
     /// ```rust
@@ -449,8 +444,6 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// * `Error::IoError` if returned by the `Source`
     /// * `Error::PageReferenceOutOfRange` if the PDB file seems corrupt
     /// * `Error::UnexpectedEof` if the string table ends prematurely
-    ///
-    /// [`StringRef`]: struct.StringRef.html
     pub fn string_table(&mut self) -> Result<StringTable<'s>> {
         let stream = self.named_stream(b"/names")?;
         StringTable::parse(stream)

--- a/src/pdbi.rs
+++ b/src/pdbi.rs
@@ -15,11 +15,11 @@ use crate::msf::*;
 
 /// A PDB info stream header parsed from a stream.
 ///
-/// The [PDB information stream][1] contains the GUID and age fields that can be used to
+/// The [PDB information stream] contains the GUID and age fields that can be used to
 /// verify that a PDB file matches a specific binary, as well a list of named PDB streams
 /// with their stream indices.
 ///
-/// [1]: http://llvm.org/docs/PDB/PdbStream.html
+/// [PDB information stream]: http://llvm.org/docs/PDB/PdbStream.html
 #[derive(Debug)]
 pub struct PDBInformation<'s> {
     /// The version of the PDB format in use.
@@ -30,12 +30,10 @@ pub struct PDBInformation<'s> {
     ///
     /// This number is bumped by the linker and other tools every time the PDB is modified. It does
     /// not necessarily correspond to the age declared in the image. Consider using
-    /// [`DebugInformation::age`] for a better match.
+    /// [`DebugInformation::age`](crate::DebugInformation::age) for a better match.
     ///
     /// This PDB matches an image, if the `guid` values match and the PDB age is equal or higher
     /// than the image's age.
-    ///
-    /// [`DebugInformation::age`]: struct.DebugInformation.html#method.age
     pub age: u32,
     /// A `Uuid` generated when this PDB file was created that should uniquely identify it.
     pub guid: Uuid,
@@ -159,11 +157,8 @@ pub struct StreamName<'n> {
 
 /// A list of named streams contained within the PDB file.
 ///
-/// Call [`StreamNames::iter`][1] to iterate over the names. The iterator produces [`StreamName`][2]
+/// Call [`StreamNames::iter`] to iterate over the names. The iterator produces [`StreamName`]
 /// objects.
-///
-/// [1]: #method.iter
-/// [2]: struct.StreamName.html
 #[derive(Debug)]
 pub struct StreamNames<'s> {
     buf: ParseBuffer<'s>,
@@ -171,9 +166,7 @@ pub struct StreamNames<'s> {
     names: Vec<StreamName<'s>>,
 }
 
-/// An iterator over [`StreamName`][1]s.
-///
-/// [1]: struct.StreamName.html
+/// An iterator over [`StreamName`]s.
 pub type NameIter<'a, 'n> = std::slice::Iter<'a, StreamName<'n>>;
 
 impl<'s> StreamNames<'s> {

--- a/src/source.rs
+++ b/src/source.rs
@@ -22,12 +22,12 @@ pub struct SourceSlice {
 
 /// The `pdb` crate accesses PDB files via the `pdb::Source` trait.
 ///
-/// This library is written with zero-copy in mind. `Source`s provide `SourceView`s which need not
+/// This library is written with zero-copy in mind. `Source`s provide [`SourceView`]s which need not
 /// outlive their parent, supporting implementations of e.g. memory mapped files.
 ///
 /// PDB files are "multi-stream files" (MSF) under the hood. MSFs have various layers of
 /// indirection, but ultimately the MSF code asks a `Source` to view a series of
-/// [`{ offset, size }` records](struct.SourceSlice.html), which the `Source` provides as a
+/// [`{ offset, size }` records](SourceSlice), which the `Source` provides as a
 /// contiguous `&[u8]`.
 ///
 /// # Default
@@ -40,8 +40,8 @@ pub struct SourceSlice {
 /// # Alignment
 ///
 /// The requested offsets will always be aligned to the MSF's page size, which is always a power of
-/// two and is usually (but not always) 4096 bytes. The requested sizes will also be multiples of the
-/// page size, except for the size of the final `SourceSlice`, which may be smaller.
+/// two and is usually (but not always) 4096 bytes. The requested sizes will also be multiples of
+/// the page size, except for the size of the final `SourceSlice`, which may be smaller.
 ///
 /// PDB files are specified as always being a multiple of the page size, so `Source` implementations
 /// are free to e.g. map whole pages and return a sub-slice of the requested length.

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -79,9 +79,7 @@ impl StringTableHeader {
 /// [`StringRef`] offsets to their string values. Sometimes, it is also referred to as "Name table".
 /// The mapping from string to offset has not been implemented yet.
 ///
-/// Use [`PDB::string_table`] to obtain an instance.
-///
-/// [`PDB::string_table`]: struct.PDB.html#method.string_table
+/// Use [`PDB::string_table`](crate::PDB::string_table) to obtain an instance.
 #[derive(Debug)]
 pub struct StringTable<'s> {
     header: StringTableHeader,
@@ -143,9 +141,7 @@ impl StringRef {
     /// Resolves the raw string value of this reference.
     ///
     /// This method errors if the offset is out of bounds of the string table. Use
-    /// [`PDB::string_table`] to obtain an instance of the string table.
-    ///
-    /// [`PDB::string_table`]: struct.PDB.html#method.string_table
+    /// [`PDB::string_table`](crate::PDB::string_table) to obtain an instance of the string table.
     pub fn to_raw_string<'s>(self, strings: &'s StringTable<'_>) -> Result<RawString<'s>> {
         strings.get(self)
     }
@@ -153,9 +149,7 @@ impl StringRef {
     /// Resolves and decodes the UTF-8 string value of this reference.
     ///
     /// This method errors if the offset is out of bounds of the string table. Use
-    /// [`PDB::string_table`] to obtain an instance of the string table.
-    ///
-    /// [`PDB::string_table`]: struct.PDB.html#method.string_table
+    /// [`PDB::string_table`](crate::PDB::string_table) to obtain an instance of the string table.
     pub fn to_string_lossy<'s>(self, strings: &'s StringTable<'_>) -> Result<Cow<'s, str>> {
         strings.get(self).map(|r| r.to_string())
     }

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -164,8 +164,6 @@ fn parse_optional_index(buf: &mut ParseBuffer<'_>) -> Result<Option<SymbolIndex>
 //   https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/cvdump/dumpsym7.cpp#L264
 
 /// Information parsed from a [`Symbol`] record.
-///
-/// [`Symbol`]: struct.Symbol.html
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SymbolData<'t> {
     /// End of a scope, such as a procedure.
@@ -192,7 +190,7 @@ pub enum SymbolData<'t> {
     CompileFlags(CompileFlagsSymbol<'t>),
     /// A using namespace directive.
     UsingNamespace(UsingNamespaceSymbol<'t>),
-    /// Reference to a [`ProcedureSymbol`](struct.ProcedureSymbol.html).
+    /// Reference to a [`ProcedureSymbol`].
     ProcedureReference(ProcedureReferenceSymbol<'t>),
     /// Reference to an imported variable.
     DataReference(DataReferenceSymbol<'t>),
@@ -473,7 +471,7 @@ pub struct ProcedureReferenceSymbol<'t> {
     pub global: bool,
     /// SUC of the name.
     pub sum_name: u32,
-    /// Symbol index of the referenced [`ProcedureSymbol`](struct.ProcedureSymbol.html).
+    /// Symbol index of the referenced [`ProcedureSymbol`].
     ///
     /// Note that this symbol might be located in a different module.
     pub symbol_index: SymbolIndex,
@@ -508,7 +506,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for ProcedureReferenceSymbol<'t> {
 pub struct DataReferenceSymbol<'t> {
     /// SUC of the name.
     pub sum_name: u32,
-    /// Symbol index of the referenced [`DataSymbol`](struct.DataSymbol.html).
+    /// Symbol index of the referenced [`DataSymbol`].
     ///
     /// Note that this symbol might be located in a different module.
     pub symbol_index: SymbolIndex,
@@ -785,8 +783,6 @@ pub struct InlineSiteSymbol<'t> {
     /// Index of the parent function.
     ///
     /// This might either be a [`ProcedureSymbol`] or another `InlineSiteSymbol`.
-    ///
-    /// [`ProcedureSymbol`]: struct.ProcedureSymbol.html
     pub parent: Option<SymbolIndex>,
     /// The end symbol of this callsite.
     pub end: SymbolIndex,
@@ -1028,7 +1024,7 @@ const CV_LVARFLAG_ISOPTIMIZEDOUT: u16 = 0x80;
 const CV_LVARFLAG_ISENREG_GLOB: u16 = 0x100;
 const CV_LVARFLAG_ISENREG_STAT: u16 = 0x200;
 
-/// Flags for a [`LocalSymbol`](struct.LocalSymbol.html).
+/// Flags for a [`LocalSymbol`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LocalVariableFlags {
     /// Variable is a parameter.
@@ -1107,7 +1103,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for LocalSymbol<'t> {
 }
 
 // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4456
-/// Flags of an [`ExportSymbol`](struct.ExportSymbol.html).
+/// Flags of an [`ExportSymbol`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ExportSymbolFlags {
     /// An exported constant.
@@ -1359,7 +1355,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for ThunkSymbol<'t> {
 const CV_SEPCODEFLAG_IS_LEXICAL_SCOPE: u32 = 0x01;
 const CV_SEPCODEFLAG_RETURNS_TO_PARENT: u32 = 0x02;
 
-/// Flags for a [`SeparatedCodeSymbol`](struct.SeparatedCodeSymbol.html).
+/// Flags for a [`SeparatedCodeSymbol`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SeparatedCodeFlags {
     /// S_SEPCODE doubles as lexical scope.

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -100,7 +100,7 @@ impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
 
 /// Global function, usually inlined.
 ///
-/// This Id is usually referenced by [`InlineSiteSymbol`](struct.InlineSiteSymbol.html).
+/// This Id is usually referenced by [`InlineSiteSymbol`](crate::InlineSiteSymbol).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionId<'t> {
     /// Parent scope of this id.
@@ -113,7 +113,7 @@ pub struct FunctionId<'t> {
 
 /// Member function, usually inlined.
 ///
-/// This Id is usually referenced by [`InlineSiteSymbol`](struct.InlineSiteSymbol.html).
+/// This Id is usually referenced by [`InlineSiteSymbol`](crate::InlineSiteSymbol).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MemberFunctionId<'t> {
     /// Index of the parent type.
@@ -126,7 +126,7 @@ pub struct MemberFunctionId<'t> {
 
 /// Tool, version and command line build information.
 ///
-/// This Id is usually referenced by [`BuildInfoSymbol`](struct.BuildInfoSymbol.html).
+/// This Id is usually referenced by [`BuildInfoSymbol`](crate::BuildInfoSymbol).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BuildInfoId {
     /// Indexes of build arguments.
@@ -135,7 +135,7 @@ pub struct BuildInfoId {
 
 /// A list of substrings.
 ///
-/// This Id is usually referenced by [`StringId`](struct.StringId.html).
+/// This Id is usually referenced by [`StringId`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringListId {
     /// The list of substrings.
@@ -144,8 +144,7 @@ pub struct StringListId {
 
 /// A string.
 ///
-/// This Id is usually referenced by [`FunctionId`](struct.FunctionId.html) and contains the
-/// full namespace of a function.
+/// This Id is usually referenced by [`FunctionId`] and contains the full namespace of a function.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringId<'t> {
     /// Index of the list of substrings.

--- a/src/tpi/mod.rs
+++ b/src/tpi/mod.rs
@@ -37,9 +37,10 @@ pub use self::primitive::{Indirection, PrimitiveKind, PrimitiveType};
 ///    functions, build infos and source references. Its contents are identified by [`IdIndex`].
 ///
 /// Items in these streams are stored by their index in ascending order. Symbols declared in
-/// [`ModuleInfo`] can refer to items in both streams, as well as items to other items with one
-/// exception: `Type`s cannot refer to `Id`s. Also, the PDB format requires that items refer only to
-/// types with lower indexes. Thus, the stream of items forms a directed acyclic graph.
+/// [`ModuleInfo`](crate::ModuleInfo) can refer to items in both streams, as well as items to other
+/// items with one exception: `Type`s cannot refer to `Id`s. Also, the PDB format requires that
+/// items refer only to types with lower indexes. Thus, the stream of items forms a directed acyclic
+/// graph.
 ///
 /// Both streams can iterate by their index using [`ItemInformation::iter`]. Additionally,
 /// [`ItemFinder`] is a secondary data structure to provide efficient backtracking for random
@@ -123,22 +124,6 @@ pub use self::primitive::{Indirection, PrimitiveKind, PrimitiveType};
 /// # }
 /// # assert!(test().expect("test") > 8000);
 /// ```
-///
-/// [`ItemInformation::iter`]: struct.ItemInformation.html#method.iter
-/// [`TypeInformation`]: type.TypeInformation.html
-/// [`IdInformation`]: type.IdInformation.html
-/// [`ItemFinder`]: struct.ItemFinder.html
-/// [`TypeFinder`]: type.TypeFinder.html
-/// [`IdFinder`]: type.IdFinder.html
-/// [`ItemIndex`]: trait.ItemIndex.html
-/// [`TypeIndex`]: struct.TypeIndex.html
-/// [`IdIndex`]: struct.IdIndex.html
-/// [`ItemIter`]: struct.ItemIter.html
-/// [`TypeIter`]: type.TypeIter.html
-/// [`IdIter`]: type.IdIter.html
-/// [`Item`]: struct.Item.html
-/// [`Type`]: type.Type.html
-/// [`Id`]: type.Id.html
 #[derive(Debug)]
 pub struct ItemInformation<'s, I> {
     stream: Stream<'s>,
@@ -184,8 +169,6 @@ where
     /// Note that in the case of the type stream ([`TypeInformation`]) primitive types are not
     /// stored in the PDB file. The number of distinct types reachable via this table will be higher
     /// than `len()`.
-    ///
-    /// [`TypeInformation`]: type.TypeInformation.html
     pub fn len(&self) -> usize {
         (self.header.maximum_index - self.header.minimum_index) as usize
     }
@@ -200,8 +183,6 @@ where
     ///
     /// The `ItemFinder` is initially empty and must be populated by iterating. See the struct-level
     /// docs for an example.
-    ///
-    /// [`ItemIndex`]: trait.ItemIndex.html
     pub fn finder(&self) -> ItemFinder<'_, I> {
         ItemFinder::new(self, 3)
     }
@@ -220,17 +201,10 @@ const PRIMITIVE_TYPE: &[u8] = b"\xff\xff";
 ///
 /// The data held by items can be parsed:
 ///
-///  - [`Type::parse`] returns [`TypeData`].
-///  - [`Id::parse`] returns [`IdData`].
+///  - [`Type::parse`](Self::parse) returns [`TypeData`].
+///  - [`Id::parse`](Self::parse) returns [`IdData`].
 ///
 /// Depending on the stream, this can either be a [`Type`] or [`Id`].
-///
-/// [`Type`]: type.Type.html
-/// [`Id`]: type.Id.html
-/// [`Type::parse`]: struct.Item.html#method.parse
-/// [`Id::parse`]: struct.Item.html#method.parse-1
-/// [`TypeData`]: enum.TypeData.html
-/// [`IdData`]: enum.IdData.html
 #[derive(Copy, Clone, PartialEq)]
 pub struct Item<'t, I> {
     index: I,
@@ -244,9 +218,6 @@ where
     /// Returns this item's index.
     ///
     /// Depending on the stream, either a [`TypeIndex`] or [`IdIndex`].
-    ///
-    /// [`TypeIndex`]: struct.TypeIndex.html
-    /// [`IdIndex`]: struct.IdIndex.html
     pub fn index(&self) -> I {
         self.index
     }
@@ -268,8 +239,6 @@ where
     /// Returns the identifier of the kind of data stored by this this `Item`.
     ///
     /// As a special case, if this is a primitive [`Type`], this function will return `0xffff`.
-    ///
-    /// [`Type`]: type.Type.html
     #[inline]
     pub fn raw_kind(&self) -> u16 {
         debug_assert!(self.data.len() >= 2);
@@ -293,13 +262,14 @@ where
     }
 }
 
-/// In-memory index for efficient random-access of [`Items`] by index.
+/// In-memory index for efficient random-access to [`Item`]s by index.
 ///
 /// `ItemFinder` can be obtained via [`ItemInformation::finder`]. It starts out empty and must be
-/// populated by calling [`update`] while iterating. There are two typedefs for easier use:
+/// populated by calling [`ItemFinder::update`] while iterating. There are two typedefs for easier
+/// use:
 ///
-///  - [`TypeFinder`] for finding [`Types`] in a [`TypeInformation`] (TPI stream).
-///  - [`IdFinder`] for finding [`Ids`] in a [`IdInformation`] (IPI stream).
+///  - [`TypeFinder`] for finding [`Type`]s in a [`TypeInformation`](crate::TypeInformation) (TPI stream).
+///  - [`IdFinder`] for finding [`Id`]s in a [`IdInformation`](crate::IdInformation) (IPI stream).
 ///
 /// `ItemFinder` allocates all the memory it needs when it is first created. The footprint is
 /// directly proportional to the total number of types; see [`ItemInformation::len`].
@@ -339,16 +309,6 @@ where
 /// A `shift` of 2 or 3 is likely appropriate for most workloads. 500K items would require 1 MB or
 /// 500 KB of memory respectively, and lookups -- though indirect -- would still usually need only
 /// one or two 64-byte cache lines.
-///
-/// [`Items`]: struct.Item.html
-/// [`ItemInformation::finder`]: struct.ItemInformation.html#method.finder
-/// [`ItemInformation::len`]: struct.ItemInformation.html#method.len
-/// [`TypeInformation`]: type.TypeInformation.html
-/// [`IdInformation`]: type.IdInformation.html
-/// [`TypeFinder`]: type.TypeFinder.html
-/// [`Types`]: type.Type.html
-/// [`IdFinder`]: type.IdFinder.html
-/// [`Ids`]: type.Id.html
 #[derive(Debug)]
 pub struct ItemFinder<'t, I> {
     buffer: ParseBuffer<'t>,
@@ -416,9 +376,6 @@ where
     ///
     /// Do this each time you call `.next()`. See documentation of [`ItemInformation`] for an
     /// example.
-    ///
-    /// [`ItemIter`]: struct.ItemIter.html
-    /// [`ItemInformation`]: struct.ItemInformation.html
     #[inline]
     pub fn update(&mut self, iterator: &ItemIter<'t, I>) {
         let (vec_index, iteration_count) = self.resolve(iterator.index);
@@ -477,14 +434,12 @@ where
     }
 }
 
-/// An iterator over items in [`TypeInformation`] or [`IdInformation`].
+/// An iterator over items in [`TypeInformation`](crate::TypeInformation) or
+/// [`IdInformation`](crate::IdInformation).
 ///
 /// The TPI and IPI streams are represented internally as a series of records, each of which have a
 /// length, a kind, and a type-specific field layout. Iteration performance is therefore similar to
 /// a linked list.
-///
-/// [`TypeInformation`]: type.TypeInformation.html
-/// [`IdInformation`]: type.IdInformation.html
 #[derive(Debug)]
 pub struct ItemIter<'t, I> {
     buf: ParseBuffer<'t>,
@@ -532,25 +487,15 @@ where
 ///
 /// This stream exposes types, the variants of which are enumerated by [`TypeData`]. See
 /// [`ItemInformation`] for more information on accessing types.
-///
-/// [`TypeData`]: enum.TypeData.html
-/// [`ItemInformation`]: struct.ItemInformation.html
 pub type TypeInformation<'s> = ItemInformation<'s, TypeIndex>;
 
-/// In-memory index for efficient random-access of [`Types`] by index.
+/// In-memory index for efficient random-access of [`Type`]s by index.
 ///
-/// `TypeFinder` can be obtained via [`TypeInformation::finder`]. See [`ItemFinder`] for more
-/// information.
-///
-/// [`Types`]: type.Type.html
-/// [`TypeInformation::finder`]: struct.ItemInformation.html#method.finder
-/// [`ItemFinder`]: struct.ItemFinder.html
+/// `TypeFinder` can be obtained via [`TypeInformation::finder`](ItemInformation::finder). See
+/// [`ItemFinder`] for more information.
 pub type TypeFinder<'t> = ItemFinder<'t, TypeIndex>;
 
-/// An iterator over [`Types`] returned by [`TypeInformation::iter`].
-///
-/// [`TypeInformation::iter`]: struct.ItemInformation.html#method.iter
-/// [`Types`]: type.Type.html
+/// An iterator over [`Type`]s returned by [`TypeInformation::iter`](ItemInformation::iter).
 pub type TypeIter<'t> = ItemIter<'t, TypeIndex>;
 
 /// Information on a primitive type, class, or procedure.
@@ -579,25 +524,15 @@ impl<'t> Item<'t, TypeIndex> {
 ///
 /// This stream exposes types, the variants of which are enumerated by [`IdData`]. See
 /// [`ItemInformation`] for more information on accessing types.
-///
-/// [`IdData`]: enum.IdData.html
-/// [`ItemInformation`]: struct.ItemInformation.html
 pub type IdInformation<'s> = ItemInformation<'s, IdIndex>;
 
-/// In-memory index for efficient random-access of [`Ids`] by index.
+/// In-memory index for efficient random-access of [`Id`]s by index.
 ///
-/// `IdFinder` can be obtained via [`IdInformation::finder`]. See [`ItemFinder`] for more
-/// information.
-///
-/// [`Ids`]: type.Id.html
-/// [`IdInformation::finder`]: struct.ItemInformation.html#method.finder
-/// [`ItemFinder`]: struct.ItemFinder.html
+/// `IdFinder` can be obtained via [`IdInformation::finder`](ItemInformation::finder). See
+/// [`ItemFinder`] for more information.
 pub type IdFinder<'t> = ItemFinder<'t, IdIndex>;
 
-/// An iterator over [`Ids`] returned by [`IdInformation::iter`].
-///
-/// [`IdInformation::iter`]: struct.ItemInformation.html#method.iter
-/// [`Ids`]: type.Id.html
+/// An iterator over [`Id`]s returned by [`IdInformation::iter`](ItemInformation::iter).
 pub type IdIter<'t> = ItemIter<'t, IdIndex>;
 
 /// Information on an inline function, build infos or source references.

--- a/src/tpi/primitive.rs
+++ b/src/tpi/primitive.rs
@@ -166,8 +166,8 @@ pub enum PrimitiveKind {
 
 /// Pointer mode of primitive types.
 ///
-/// This is partially overlapping with [`PointerKind`](enum.PointerKind.html) for regular pointer
-/// type definitions. While `PointerKind` can specify many more pointer types, including relative
+/// This is partially overlapping with [`PointerKind`](crate::PointerKind) for regular pointer type
+/// definitions. While `PointerKind` can specify many more pointer types, including relative
 /// pointers, `Indirection` also contains a 128-bit variant.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Indirection {


### PR DESCRIPTION
With intra doc links having landed on stable and enabled by default on docs.rs,
we can now adopt intra doc links across the code base in favor of direct links
to HTML pages. This also uncovered a number of broken links that have been fixed
now.

I've added an additional Travis job to verify that all links are valid.