### PR TITLE
Fix Rust 1.49 clippy lints and Edition 2018 idioms

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -545,7 +545,7 @@ impl StreamIndex {
 }
 
 impl fmt::Display for StreamIndex {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.msf_number() {
             Some(number) => write!(f, "{}", number),
             None => write!(f, "None"),
@@ -554,7 +554,7 @@ impl fmt::Display for StreamIndex {
 }
 
 impl fmt::Debug for StreamIndex {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "StreamIndex({})", self)
     }
 }
@@ -855,7 +855,7 @@ pub enum Variant {
 }
 
 impl fmt::Display for Variant {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Variant::U8(value) => write!(f, "{}", value),
             Variant::U16(value) => write!(f, "{}", value),

--- a/src/framedata.rs
+++ b/src/framedata.rs
@@ -43,7 +43,7 @@ pub enum FrameType {
 }
 
 impl fmt::Display for FrameType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FrameType::Unknown => write!(f, "unknown"),
             FrameType::FPO => write!(f, "fpo"),
@@ -146,7 +146,7 @@ impl NewFrameData {
 }
 
 impl fmt::Debug for NewFrameData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NewFrameData")
             .field("code_start", &self.code_start())
             .field("code_size", &self.code_size())
@@ -249,7 +249,7 @@ impl OldFrameData {
 }
 
 impl fmt::Debug for OldFrameData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OldFrameData")
             .field("code_start", &self.code_start())
             .field("code_size", &self.code_size())

--- a/src/modi/c13.rs
+++ b/src/modi/c13.rs
@@ -36,7 +36,7 @@ enum DebugSubsectionKind {
 
 impl DebugSubsectionKind {
     fn parse(value: u32) -> Result<Option<Self>> {
-        if value >= 0xf1 && value <= 0xfd {
+        if (0xf1..=0xfd).contains(&value) {
             Ok(Some(unsafe { std::mem::transmute(value) }))
         } else if value == constants::DEBUG_S_IGNORE {
             Ok(None)
@@ -351,8 +351,8 @@ impl LineNumberHeader {
         // that they are not confused with actual line number entries.
         let start_line = self.flags & 0x00ff_ffff;
         let marker = match start_line {
-            0xfee_fee => Some(LineMarkerKind::DoNotStepOnto),
-            0xf00_f00 => Some(LineMarkerKind::DoNotStepInto),
+            0xfeefee => Some(LineMarkerKind::DoNotStepOnto),
+            0xf00f00 => Some(LineMarkerKind::DoNotStepInto),
             _ => None,
         };
 

--- a/src/modi/mod.rs
+++ b/src/modi/mod.rs
@@ -235,7 +235,7 @@ impl<'a> LineProgram<'a> {
     /// Note that line records are not guaranteed to be ordered by source code offset. If a
     /// monotonic order by `PdbInternalSectionOffset` or `Rva` is required, the lines have to be
     /// sorted manually.
-    pub fn lines_at_offset(&self, offset: PdbInternalSectionOffset) -> LineIterator {
+    pub fn lines_at_offset(&self, offset: PdbInternalSectionOffset) -> LineIterator<'_> {
         match self.inner {
             LineProgramInner::C13(ref inner) => LineIterator {
                 inner: LineIteratorInner::C13(inner.lines_at_offset(offset)),

--- a/src/msf/mod.rs
+++ b/src/msf/mod.rs
@@ -97,7 +97,7 @@ mod big {
             let mut offset = 0;
             let data = RawHeader {
                 magic: {
-                    let mut tmp = [0; 32 as usize];
+                    let mut tmp = [0; 32];
                     this.gread_inout_with(&mut offset, &mut tmp, le)?;
                     tmp
                 },

--- a/src/msf/page_list.rs
+++ b/src/msf/page_list.rs
@@ -87,9 +87,7 @@ impl PageList {
 
     /// Return the total length of this PageList.
     pub fn len(&self) -> usize {
-        self.source_slices
-            .iter()
-            .fold(0 as usize, |acc, s| acc + s.size)
+        self.source_slices.iter().fold(0, |acc, s| acc + s.size)
     }
 
     /// Return a slice of SourceSlices.

--- a/src/omap.rs
+++ b/src/omap.rs
@@ -60,7 +60,7 @@ impl OMAPRecord {
 }
 
 impl fmt::Debug for OMAPRecord {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OMAPRecord")
             .field(
                 "source_address",
@@ -185,7 +185,7 @@ impl<'s> OMAPTable<'s> {
 }
 
 impl fmt::Debug for OMAPTable<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("OMAPTable").field(&self.records()).finish()
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -55,7 +55,7 @@ pub trait Source<'s>: fmt::Debug {
 }
 
 /// An owned, droppable, read-only view of the source file which can be referenced as a byte slice.
-pub trait SourceView<'s>: Drop + fmt::Debug {
+pub trait SourceView<'s>: fmt::Debug {
     /// Returns a view to the raw data.
     fn as_slice(&self) -> &[u8];
 }
@@ -77,18 +77,12 @@ impl SourceView<'_> for ReadView {
     }
 }
 
-impl Drop for ReadView {
-    fn drop(&mut self) {
-        // no-op
-    }
-}
-
 impl<'s, T> Source<'s> for T
 where
     T: io::Read + io::Seek + fmt::Debug + 's,
 {
     fn view(&mut self, slices: &[SourceSlice]) -> Result<Box<dyn SourceView<'s>>, io::Error> {
-        let len = slices.iter().fold(0 as usize, |acc, s| acc + s.size);
+        let len = slices.iter().fold(0, |acc, s| acc + s.size);
 
         let mut v = ReadView {
             bytes: Vec::with_capacity(len),

--- a/src/symbol/annotations.rs
+++ b/src/symbol/annotations.rs
@@ -110,12 +110,12 @@ pub enum BinaryAnnotation {
 impl BinaryAnnotation {
     /// Does this annotation emit a line info?
     pub fn emits_line_info(self) -> bool {
-        match self {
-            BinaryAnnotation::ChangeCodeOffset(..) => true,
-            BinaryAnnotation::ChangeCodeOffsetAndLineOffset(..) => true,
-            BinaryAnnotation::ChangeCodeLengthAndCodeOffset(..) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            BinaryAnnotation::ChangeCodeOffset(..)
+                | BinaryAnnotation::ChangeCodeOffsetAndLineOffset(..)
+                | BinaryAnnotation::ChangeCodeLengthAndCodeOffset(..)
+        )
     }
 }
 

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -414,7 +414,7 @@ pub(crate) fn parse_type_data<'t>(mut buf: &mut ParseBuffer<'t>) -> Result<TypeD
 }
 
 #[inline]
-fn parse_optional_type_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<TypeIndex>> {
+fn parse_optional_type_index(buf: &mut ParseBuffer<'_>) -> Result<Option<TypeIndex>> {
     let index = buf.parse()?;
     if index == TypeIndex(0) || index == TypeIndex(0xffff) {
         Ok(None)
@@ -433,7 +433,7 @@ fn parse_string<'t>(leaf: u16, buf: &mut ParseBuffer<'t>) -> Result<RawString<'t
 }
 
 #[inline]
-fn parse_padding<'t>(buf: &mut ParseBuffer<'t>) -> Result<()> {
+fn parse_padding(buf: &mut ParseBuffer<'_>) -> Result<()> {
     while !buf.is_empty() && buf.peek_u8()? >= 0xf0 {
         let padding = buf.parse_u8()?;
         if padding > 0xf0 {
@@ -446,7 +446,7 @@ fn parse_padding<'t>(buf: &mut ParseBuffer<'t>) -> Result<()> {
 }
 
 // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/pdbdump/pdbdump.cpp#L2417-L2456
-fn parse_unsigned<'t>(buf: &mut ParseBuffer<'t>) -> Result<u64> {
+fn parse_unsigned(buf: &mut ParseBuffer<'_>) -> Result<u64> {
     let leaf = buf.parse_u16()?;
     if leaf < LF_NUMERIC {
         // the u16 directly encodes a value

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -4,7 +4,7 @@ use crate::common::*;
 use crate::tpi::constants::*;
 
 #[inline]
-fn parse_optional_id_index<'t>(buf: &mut ParseBuffer<'t>) -> Result<Option<IdIndex>> {
+fn parse_optional_id_index(buf: &mut ParseBuffer<'_>) -> Result<Option<IdIndex>> {
     Ok(match buf.parse()? {
         IdIndex(0) => None,
         index => Some(index),

--- a/tests/symbol_table.rs
+++ b/tests/symbol_table.rs
@@ -78,7 +78,7 @@ fn find_symbols() {
             return;
         }
 
-        let mut map: HashMap<&[u8], Option<pdb::SymbolData>> = HashMap::new();
+        let mut map: HashMap<&[u8], Option<pdb::SymbolData<'_>>> = HashMap::new();
 
         // look for:
         // main(), defined in the program


### PR DESCRIPTION
This is currently breaking on master.

The only functional change is that the `SourceView` trait no longer requires `Drop`. See [`drop_bounds`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#drop-bounds) for more arguments why this is not needed.