### PR TITLE
fix: Allow parsing modules that have no symbols

### DIFF
--- a/src/modi/mod.rs
+++ b/src/modi/mod.rs
@@ -61,7 +61,7 @@ impl<'s> ModuleInfo<'s> {
             let sig = buf.parse_u32()?;
             if sig != constants::CV_SIGNATURE_C13 {
                 return Err(Error::UnimplementedFeature(
-                    "Unsupported module info format",
+                    "Unsupported symbol data format",
                 ));
             }
         }

--- a/src/modi/mod.rs
+++ b/src/modi/mod.rs
@@ -31,15 +31,8 @@ pub struct ModuleInfo<'s> {
 
 impl<'s> ModuleInfo<'s> {
     /// Parses a `ModuleInfo` from it's Module info stream data.
-    pub(crate) fn parse(stream: Stream<'s>, module: &Module<'_>) -> Result<Self> {
+    pub(crate) fn parse(stream: Stream<'s>, module: &Module<'_>) -> Self {
         let info = module.info();
-
-        let mut buf = stream.parse_buffer();
-        if buf.parse_u32()? != constants::CV_SIGNATURE_C13 {
-            return Err(Error::UnimplementedFeature(
-                "Unsupported module info format",
-            ));
-        }
 
         let lines_size = if info.lines_size > 0 {
             LinesSize::C11(info.lines_size as usize)
@@ -48,11 +41,11 @@ impl<'s> ModuleInfo<'s> {
         };
 
         let symbols_size = info.symbols_size as usize;
-        Ok(ModuleInfo {
+        ModuleInfo {
             stream,
             symbols_size,
             lines_size,
-        })
+        }
     }
 
     fn lines_data(&self, size: usize) -> &[u8] {
@@ -64,7 +57,14 @@ impl<'s> ModuleInfo<'s> {
     pub fn symbols(&self) -> Result<SymbolIter<'_>> {
         let mut buf = self.stream.parse_buffer();
         buf.truncate(self.symbols_size)?;
-        buf.parse_u32()?;
+        if self.symbols_size > 0 {
+            let sig = buf.parse_u32()?;
+            if sig != constants::CV_SIGNATURE_C13 {
+                return Err(Error::UnimplementedFeature(
+                    "Unsupported module info format",
+                ));
+            }
+        }
         Ok(SymbolIter::new(buf))
     }
 

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -215,10 +215,9 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
     /// # }
     /// ```
     pub fn module_info<'m>(&mut self, module: &Module<'m>) -> Result<Option<ModuleInfo<'s>>> {
-        match self.raw_stream(module.info().stream)? {
-            Some(stream) => ModuleInfo::parse(stream, module).map(Some),
-            None => Ok(None),
-        }
+        Ok(self
+            .raw_stream(module.info().stream)?
+            .map(|stream| ModuleInfo::parse(stream, module)))
     }
 
     /// Retrieve the executable's section headers, as stored inside this PDB.


### PR DESCRIPTION
The expected CV Signature of a ModuleInfo seems to be a part of the
symbols, meaning that we shouldn’t read it when the symbols_size is 0.