### PR TITLE
Retain u64 size for class and union sizes

### DIFF
--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -101,7 +101,7 @@ pub(crate) fn parse_type_data<'t>(mut buf: &mut ParseBuffer<'t>) -> Result<TypeD
                 derived_from: parse_optional_type_index(&mut buf)?,
                 vtable_shape: parse_optional_type_index(&mut buf)?,
                 count: buf.parse_u16()?,
-                size: parse_unsigned(&mut buf)? as u16,
+                size: parse_unsigned(&mut buf)?,
                 name: parse_string(leaf, buf)?,
                 unique_name: None,
             };

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -117,7 +117,7 @@ pub(crate) fn parse_type_data<'t>(mut buf: &mut ParseBuffer<'t>) -> Result<TypeD
         LF_MEMBER | LF_MEMBER_ST => Ok(TypeData::Member(MemberType {
             attributes: FieldAttributes(buf.parse_u16()?),
             field_type: buf.parse()?,
-            offset: parse_unsigned(&mut buf)? as u16,
+            offset: parse_unsigned(&mut buf)?,
             name: parse_string(leaf, &mut buf)?,
         })),
 
@@ -868,7 +868,7 @@ pub enum ClassKind {
 pub struct MemberType<'t> {
     pub attributes: FieldAttributes,
     pub field_type: TypeIndex,
-    pub offset: u16,
+    pub offset: u64,
     pub name: RawString<'t>,
 }
 

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -80,7 +80,7 @@ pub(crate) fn parse_type_data<'t>(mut buf: &mut ParseBuffer<'t>) -> Result<TypeD
                 fields: parse_optional_type_index(&mut buf)?,
                 derived_from: parse_optional_type_index(&mut buf)?,
                 vtable_shape: parse_optional_type_index(&mut buf)?,
-                size: parse_unsigned(&mut buf)? as u16,
+                size: parse_unsigned(&mut buf)?,
                 name: parse_string(leaf, buf)?,
                 unique_name: None,
             };
@@ -324,7 +324,7 @@ pub(crate) fn parse_type_data<'t>(mut buf: &mut ParseBuffer<'t>) -> Result<TypeD
                 count: buf.parse_u16()?,
                 properties: TypeProperties(buf.parse_u16()?),
                 fields: buf.parse()?,
-                size: parse_unsigned(&mut buf)? as u32,
+                size: parse_unsigned(&mut buf)?,
                 name: parse_string(leaf, &mut buf)?,
                 unique_name: None,
             };
@@ -846,7 +846,7 @@ pub struct ClassType<'t> {
     /// Type index which describes the shape of the vtable for this class, if any
     pub vtable_shape: Option<TypeIndex>,
 
-    pub size: u16,
+    pub size: u64,
 
     /// Display name of the class including type parameters.
     pub name: RawString<'t>,
@@ -1018,7 +1018,7 @@ pub struct UnionType<'t> {
     pub count: u16,
     pub properties: TypeProperties,
     pub fields: TypeIndex,
-    pub size: u32,
+    pub size: u64,
     pub name: RawString<'t>,
     pub unique_name: Option<RawString<'t>>,
 }


### PR DESCRIPTION
I encountered a PDB which contained a type looking something like this:

```rust
ClassType {
    kind: Struct,
    count: 0x10,
    properties: TypeProperties(
        0x200,
    ),
    fields: Some(
        TypeIndex(0x5326),
    ),
    derived_from: None,
    vtable_shape: None,
    size: 0x5D00,
    name: RawString("_REDACTED_DATA"),
    unique_name: Some(
        RawString(".?AU_REDACTED_DATA@@"),
    ),
}
```

I noticed something weird about all structs containing this one: all of them had incorrect field offsets (calculated by me) and incorrect sizes. Upon further observation I noticed that the `size` had been truncated from `0xF5D00` to `0x5D00`. This patch removes the integer truncation from classes/structs (tested) and from unions (untested) and changes their types to be `u64`.