### PR TITLE
Fix DBIExtraStreams offset calculation

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -617,7 +617,6 @@ impl DBIExtraStreams {
                 + header.section_map_size
                 + header.file_info_size
                 + header.type_server_map_size
-                + header.mfc_type_server_index
                 + header.ec_substream_size) as usize;
 
         // seek


### PR DESCRIPTION
I was referencing this project to figure out pdb format, and I think this calculation is wrong, although `mfc_type_server_index` looks to be 0 in pdb's which may be why its went unnoticed, going off of <https://llvm.org/docs/PDB/DbiStream.html> there should only be 6 substream sizes, and the index should be irrelevant