### PR TITLE
Add two missing symbol type constants.

### DIFF
--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -268,6 +268,9 @@ pub const S_LDATA_HLSL32: u16 = 0x1163;
 pub const S_GDATA_HLSL32_EX: u16 = 0x1164;
 pub const S_LDATA_HLSL32_EX: u16 = 0x1165;
 
+pub const S_FASTLINK: u16 = 0x1167; // generated at link time for /DEBUG:FASTLINK
+pub const S_INLINEES: u16 = 0x1168;
+
 /// These values correspond to the CV_CPU_TYPE_e enumeration, and are documented
 /// [on MSDN](https://msdn.microsoft.com/en-us/library/b2fc64ek.aspx).
 #[non_exhaustive]


### PR DESCRIPTION
I got these from https://llvm.org/docs/PDB/CodeViewSymbols.html#s-fastlink-0x1167 .

There's a PDB file in https://github.com/mstange/pdb-addr2line/issues/52#issuecomment-1130225425 which uses S_FASTLINK.