### PR TITLE
Add `DebugInformation::is_stripped` to easily query to see if PDB is stripped

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -88,6 +88,17 @@ impl<'s> DebugInformation<'s> {
         }
     }
 
+    /// Returns whether or not this PDB has been marked as stripped. Stripped PDBs do not contain
+    /// type information, line number information, or per-object CV symbols.
+    /// 
+    /// This flag is set when a PDB is written with [/PDBSTRIPPED] by MSVC.
+    /// 
+    /// [/PDBSTRIPPED]: https://learn.microsoft.com/en-us/cpp/build/reference/pdbstripped-strip-private-symbols?view=msvc-170
+    pub fn is_stripped(&self) -> bool {
+        // flags.fStripped
+        (self.header.flags & 0x2) != 0
+    }
+
     /// Returns an iterator that can traverse the modules list in sequential order.
     pub fn modules(&self) -> Result<ModuleIter<'_>> {
         let mut buf = self.stream.parse_buffer();


### PR DESCRIPTION
This flag is set in PDB headers if `/PDBSTRIPPED` is passed from MSVC.
We should expose this flag so that users can easily classify PDB files as stripped or non-stripped.