### PR TITLE
Implement managed procedures and local var slots

### DIFF
--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -32,6 +32,9 @@ fn print_symbol(symbol: &pdb::Symbol<'_>) -> pdb::Result<()> {
                 Some(name) => print_row(data.offset, "function", name),
             }
         }
+        pdb::SymbolData::ManagedSlot(data) => {
+            print_row(data.offset, "data", data.name);
+        }
         _ => {
             // ignore everything else
         }

--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use getopts::Options;
-use pdb::{FallibleIterator, PdbInternalSectionOffset};
+use pdb::{FallibleIterator, PdbInternalSectionOffset, RawString};
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} input.pdb", program);
@@ -25,6 +25,12 @@ fn print_symbol(symbol: &pdb::Symbol<'_>) -> pdb::Result<()> {
         }
         pdb::SymbolData::Procedure(data) => {
             print_row(data.offset, "function", data.name);
+        }
+        pdb::SymbolData::ManagedProcedure(data) => {
+            match data.name {
+                None => print_row(data.offset, "function", RawString::from(&b"<empty>"[..])),
+                Some(name) => print_row(data.offset, "function", name),
+            }
         }
         _ => {
             // ignore everything else

--- a/src/common.rs
+++ b/src/common.rs
@@ -605,6 +605,14 @@ impl_pread!(TypeIndex);
 
 impl ItemIndex for TypeIndex {}
 
+/// COM+ metadata token for managed procedures (`CV_tkn_t`).
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct COMToken(pub u32);
+
+impl_convert!(COMToken, u32);
+impl_hex_fmt!(COMToken);
+impl_pread!(COMToken);
+
 /// Index of an [`Id`](crate::Id) in [`IdInformation`](crate::IdInformation) stream.
 ///
 /// If this index is a [cross module reference](ItemIndex::is_cross_module), it must be resolved


### PR DESCRIPTION
# Overview 
I added support for the managed symbols missing from [.NET PDBs](https://github.com/willglynn/pdb/issues/145):
- `S_TOKENREF`
- `S_OEM` (basic)
- `S_LMANPROC`
- `S_GMANPROC`
- `S_MANSLOT`
- `S_MANSLOT_ST`

Now it's possible to view the names of properties, constructors, methods and local variables of C#-originating PDBs (could be helpful for Visual Basic, I haven't checked). I extended [`pdb_symbols`]() example to include the managed symbols.